### PR TITLE
2nd page2 - widgets

### DIFF
--- a/app/how-many-visitors-do-you-need/page.tsx
+++ b/app/how-many-visitors-do-you-need/page.tsx
@@ -4,6 +4,7 @@ import { Quote } from "@/components/tutorial/quote";
 import { SectionFooter } from "@/components/tutorial/section-footer";
 import { WidgetFrame } from "@/components/tutorial/widget-frame";
 import { SamplingDistributionBuilder } from "@/components/tutorial/sampling-distribution-builder";
+import { BaselineDistributionWidget } from "@/components/tutorial/baseline-distribution-widget";
 import { getChapter, totalChapters } from "@/components/tutorial/chapters";
 import { siteConfig } from "@/lib/site-config";
 
@@ -81,6 +82,13 @@ export default function Section2Page() {
           <SamplingDistributionBuilder />
         </WidgetFrame>
       </div>
+
+      <div className="mt-8">
+        <WidgetFrame>
+          <BaselineDistributionWidget />
+        </WidgetFrame>
+      </div>
+
 
       <div className="mt-8 space-y-4 text-foreground/70">
         <p>

--- a/app/how-many-visitors-do-you-need/page.tsx
+++ b/app/how-many-visitors-do-you-need/page.tsx
@@ -84,6 +84,12 @@ export default function Section2Page() {
       </div>
 
       <div className="mt-8">
+        <p className="mb-4 text-foreground/70">
+          To keep the picture stable, this next chart does not draw random
+          samples. It shows the theoretical shape you would get if you ran this
+          100-visitor experiment over and over. In Chapter 3, we will unpack
+          where that shape comes from.
+        </p>
         <WidgetFrame>
           <BaselineDistributionWidget />
         </WidgetFrame>

--- a/app/how-many-visitors-do-you-need/page.tsx
+++ b/app/how-many-visitors-do-you-need/page.tsx
@@ -26,15 +26,49 @@ export default function Section2Page() {
       </h1>
 
       <p className="mt-6 text-foreground/70">
-        You know small samples lie. So the next question is obvious: how many
-        visitors do you actually need? There&apos;s no universal number. It
-        depends on three things, and we&apos;ll work through each one. First
-        up: your baseline conversion rate.
+        Small samples are noisy. You saw that in chapter 1. What wasn&apos;t
+        obvious yet is that noise has a shape, and the shape depends on a
+        single number: how often your visitors currently convert. Once that
+        shape is on the page, &ldquo;how many visitors do I need&rdquo; stops
+        being a vibe and starts being something you can answer.
       </p>
 
       <hr className="my-10 border-foreground/10" />
 
       <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+        The shape of noise
+      </h2>
+
+      <p className="mt-4 text-foreground/70">
+        Back to the marble jar from page 1. Same 20% true rate, same 10-marble
+        draw. This time, forget the single sample. Keep drawing and stack
+        every count onto the chart below. You&apos;re building up a tally of
+        which outcomes show up, and how often.
+      </p>
+
+      <div className="mt-6">
+        <WidgetFrame>
+          <SamplingDistributionBuilder />
+        </WidgetFrame>
+      </div>
+
+      <div className="mt-8 space-y-4 text-foreground/70">
+        <p>
+          What you just stacked has a name: a{" "}
+          <strong>sampling distribution</strong>. Each column is a possible
+          outcome of one draw, and the height is how often that outcome has
+          turned up so far. The shape is jagged because 10 marbles is a tiny
+          sample and a few dozen draws is a small pile. Scale both up, to 100
+          visitors per sample and many thousands of draws, and the histogram
+          smooths into a bell.
+        </p>
+        <p>
+          That bell isn&apos;t fixed, though. Its width moves with your
+          baseline.
+        </p>
+      </div>
+
+      <h2 className="mt-10 text-2xl font-semibold tracking-tight sm:text-3xl">
         What&apos;s a baseline?
       </h2>
 
@@ -55,59 +89,50 @@ export default function Section2Page() {
       </p>
 
       <p className="mt-4 text-foreground/70">
-        Back to our experiment: version A was getting 10 signups from 100
-        visitors, a 10% baseline. That&apos;s on the high side. Many real
-        signup flows convert somewhere between 1% and 5%, and the difference
-        matters a lot. Here&apos;s why.
+        In the case study, version A got 10 signups from 100 visitors, so the
+        baseline is 10%. That&apos;s on the high side. Many real signup flows
+        sit somewhere between 1% and 5%, and the difference matters a lot.
+        Here&apos;s what it looks like on the distribution.
       </p>
 
       <h2 className="mt-10 text-2xl font-semibold tracking-tight sm:text-3xl">
-        Two products, two completely different problems
+        Baseline changes the shape
       </h2>
 
       <p className="mt-4 text-foreground/70">
-        Imagine two SaaS products, both testing new signup button copy, both
-        hoping for a 20% relative lift. One converts at 2%. The other at 20%.
+        Two products, both hoping a new signup button lifts conversions by
+        10%. One converts at 2% today; the other at 20%. Same &ldquo;10%
+        better&rdquo; on paper. On the distribution, they are not the same
+        story.
       </p>
 
       <p className="mt-4 text-foreground/70">
-        At 2%, 100 visitors gives you roughly 2 signups. A 20% lift would take
-        that to 2.4 — less than one extra person in a hundred. At 20%, 100
-        visitors gives you 20 signups, and the same lift takes that to 24.
-        Move the slider below and watch what that looks like.
+        The widget below is the smoothed version of what you just drew,
+        scaled to 100 visitors per sample. Slide the baseline to pick a
+        product. The solid line is that product&apos;s current average. The
+        dashed line is where version B lands if it really does lift by 10%.
+        The question to sit with: does the lift line poke out of the bell, or
+        is it still inside the average&apos;s usual wobble?
       </p>
 
-      <div className="mt-8">
-        <WidgetFrame>
-          <SamplingDistributionBuilder />
-        </WidgetFrame>
-      </div>
-
-      <div className="mt-8">
-        <p className="mb-4 text-foreground/70">
-          To keep the picture stable, this next chart does not draw random
-          samples. It shows the theoretical shape you would get if you ran this
-          100-visitor experiment over and over. In Chapter 3, we will unpack
-          where that shape comes from.
-        </p>
+      <div className="mt-6">
         <WidgetFrame>
           <BaselineDistributionWidget />
         </WidgetFrame>
       </div>
 
-
       <div className="mt-8 space-y-4 text-foreground/70">
         <p>
-          At low baseline, the expected gap between A and B is less than one
-          signup per 100 visitors. That&apos;s smaller than the random noise
-          you&apos;d get by chance. You could run the test and see 2 vs. 2, or
-          2 vs. 3, or 3 vs. 2, and none of it would tell you anything. The
-          signal is buried.
+          At 2%, the lift line sits deep inside the spread. Run the test at
+          100 visitors and you&apos;d see 2 vs. 2 one day, 2 vs. 3 the next, 3
+          vs. 2 the day after. The real improvement is there; it is buried
+          under the sample-to-sample bouncing.
         </p>
         <p>
-          At higher baseline, the gap grows large enough that at least
-          something is visible. It&apos;s still noisy at 100 visitors, but
-          there&apos;s something to work with.
+          Slide the baseline up to 20% and the lift line separates from the
+          average. Single samples still vary, but the gap is wide enough that
+          &ldquo;B is better&rdquo; starts to hold up from one run to the
+          next. Same 10% improvement, very different picture.
         </p>
       </div>
 
@@ -139,30 +164,42 @@ export default function Section2Page() {
           That gap compounds fast. A landing page at 2% baseline typically
           needs 10 to 20 times more visitors than a checkout flow at 30% to
           run the same test at the same confidence. Same relative improvement,
-          completely different data requirement, because the signal is that
-          much rarer.
+          very different data requirement, because the signal is that much
+          rarer.
         </p>
         <p>
-          This is why there&apos;s no universal answer to &ldquo;how many
-          visitors do I need?&rdquo; You have to start with your own baseline.
+          That&apos;s why there&apos;s no universal answer to &ldquo;how many
+          visitors do I need?&rdquo; You start with your own baseline.
         </p>
         <p>
-          One thing worth naming: we&apos;ve been using 100 visitors throughout
-          because the numbers are easy to follow. Real A/B tests don&apos;t run
-          at that scale. By the time you finish this guide, you&apos;ll see that
-          depending on your baseline, a well-designed experiment might need
-          thousands of visitors per group, not hundreds. The examples are simple
-          on purpose. The actual numbers rarely are.
+          We&apos;ve been using 100 visitors throughout because the numbers
+          are easy to follow. Real A/B tests rarely run at that scale. By the
+          time you finish this guide, you&apos;ll see that depending on your
+          baseline, a well-designed experiment might need thousands of
+          visitors per group, not hundreds. The examples are simple on
+          purpose. The actual numbers rarely are.
         </p>
       </div>
 
+      <h2 className="mt-10 text-2xl font-semibold tracking-tight sm:text-3xl">
+        What&apos;s still missing
+      </h2>
+
+      <p className="mt-4 text-foreground/70">
+        We drew one bell: the control&apos;s. Version B has its own bell,
+        centered on a slightly different average. When the two bells overlap
+        a lot, you can&apos;t tell them apart from a single experiment. When
+        they pull apart, you can. That&apos;s the whole game, and it&apos;s
+        where we go next.
+      </p>
+
       <SectionFooter
         summary={[
-          "Your baseline is your current conversion rate before any changes.",
-          "Low baseline means rare conversions, so you need much more data to detect a real difference.",
-          "The same relative improvement is far harder to see at 2% than at 15%.",
+          "Noise has a shape. Keep drawing samples and that shape fills in: a sampling distribution.",
+          "Baseline controls the shape. The lower the baseline, the more the spread swamps small differences.",
+          "Whether a lift is visible depends on whether it separates from the spread. At 2%, a 10% lift hides. At 20%, it shows.",
         ]}
-        teaserText="Next: even with the right sample size, how confident do you need to be in the result?"
+        teaserText="Next: draw version B's bell alongside the control and watch when the two actually pull apart."
         nextLabel="Next: Confidence →"
         nextHref="/how-sure-do-you-need-to-be"
       />

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -150,17 +150,17 @@ export function BaselineDistributionWidget() {
   return (
     <div className="flex flex-col items-center gap-6">
       <div className="flex w-full max-w-[560px] items-center gap-4">
-        <label className="shrink-0 text-sm font-medium text-foreground/70">
+        <label htmlFor="baseline-slider" className="shrink-0 text-sm font-medium text-foreground/70">
           Baseline:
         </label>
         <input
+          id="baseline-slider"
           type="range"
           min={0}
           max={CH2_BASELINE_STEPS.length - 1}
           step={1}
           value={baselineIndex}
           onChange={handleBaselineChange}
-          aria-label="Baseline conversion rate"
           aria-valuetext={`${(baseline * 100).toFixed(0)}%`}
           className="flex-1"
         />

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -42,8 +42,10 @@ function buildTheoreticalBuckets({
   // P(K=0) = (1-p)^n
   let prob = Math.pow(1 - p, n);
   for (let k = 0; k <= n; k += 1) {
-    const ratePct = Math.min(maxBin, Math.round((k / n) * 100));
-    raw[ratePct] += prob;
+    const ratePct = Math.round((k / n) * 100);
+    if (ratePct <= maxBin) raw[ratePct] += prob;
+    // out-of-range outcomes are silently dropped; we scale against the full
+    // probability mass (1.0) below so visible bins stay proportionally faithful.
 
     // P(K=k+1) = P(K=k) * (n-k)/(k+1) * p/(1-p)
     if (k < n) {
@@ -52,17 +54,17 @@ function buildTheoreticalBuckets({
     }
   }
 
-  const rawSum = raw.reduce((acc, v) => acc + v, 0);
-  if (rawSum <= 0) {
+  const visibleMass = raw.reduce((acc, v) => acc + v, 0);
+  if (visibleMass <= 0) {
     buckets[Math.min(maxBin, Math.max(0, Math.round(p * 100)))] = totalDots;
     return buckets;
   }
 
-  // rawSum ≈ 1 because all overflow is clamped into raw[maxBin]; divide only
-  // to guard against floating-point drift away from exactly 1.
-  const scaled = raw.map((v) => (v / rawSum) * totalDots);
+  // Scale against 1.0 (full probability), not visibleMass, so that each bin
+  // reflects its true share of totalDots and overflow tails don't spike the edge.
+  const scaled = raw.map((v) => v * totalDots);
   const floored = scaled.map((v) => Math.floor(v));
-  let remaining = totalDots - floored.reduce((acc, v) => acc + v, 0);
+  let remaining = Math.round(visibleMass * totalDots) - floored.reduce((acc, v) => acc + v, 0);
 
   const remainders = scaled
     .map((v, idx) => ({ idx, frac: v - Math.floor(v) }))

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, type ChangeEvent } from "react";
 import { binomialSD } from "@/maths/sampling";
 import { SamplingRateDistribution } from "./sampling-rate-distribution";
 import {
@@ -42,10 +42,8 @@ function buildTheoreticalBuckets({
   // P(K=0) = (1-p)^n
   let prob = Math.pow(1 - p, n);
   for (let k = 0; k <= n; k += 1) {
-    const ratePct = Math.round((k / n) * 100);
-    if (ratePct >= 0 && ratePct <= maxBin) {
-      raw[ratePct] += prob;
-    }
+    const ratePct = Math.min(maxBin, Math.round((k / n) * 100));
+    raw[ratePct] += prob;
 
     // P(K=k+1) = P(K=k) * (n-k)/(k+1) * p/(1-p)
     if (k < n) {
@@ -60,6 +58,8 @@ function buildTheoreticalBuckets({
     return buckets;
   }
 
+  // rawSum ≈ 1 because all overflow is clamped into raw[maxBin]; divide only
+  // to guard against floating-point drift away from exactly 1.
   const scaled = raw.map((v) => (v / rawSum) * totalDots);
   const floored = scaled.map((v) => Math.floor(v));
   let remaining = totalDots - floored.reduce((acc, v) => acc + v, 0);
@@ -107,7 +107,7 @@ export function BaselineDistributionWidget() {
     debounceRef.current = setTimeout(() => {
       const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
       setLiveText(
-        `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Showing the theoretical distribution for 100 visitors.`,
+        `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Showing the theoretical distribution for ${CH2_N} visitors.`,
       );
     }, CH2_DEBOUNCE_MS);
     return () => {
@@ -115,14 +115,10 @@ export function BaselineDistributionWidget() {
     };
   }, [baseline]);
 
-  const handleBaselineChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleBaselineChange = (e: ChangeEvent<HTMLInputElement>) => {
     const idx = Number(e.target.value);
     const next = CH2_BASELINE_STEPS[Math.min(CH2_BASELINE_STEPS.length - 1, Math.max(0, idx))];
     setBaseline(next);
-    const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
-    setLiveText(
-      `Baseline changed to ${(next * 100).toFixed(0)}%. Lift marker at ${(lifted * 100).toFixed(1)}%.`,
-    );
   };
 
   const theoryBuckets = useMemo(() => {

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -45,7 +45,7 @@ export function BaselineDistributionWidget() {
             setHasDrawn(true);
             const sd = binomialSD(CH2_N, currentBaseline) / CH2_N;
             const lo = Math.max(0, (currentBaseline - 2 * sd) * 100);
-            const hi = Math.min(35, (currentBaseline + 2 * sd) * 100);
+            const hi = Math.min(CH2_AXIS_MAX * 100, (currentBaseline + 2 * sd) * 100);
             const lifted = Math.min(CH2_AXIS_MAX, currentBaseline * (1 + CH2_LIFT));
             setLiveText(
               `Drew 100 samples at ${(currentBaseline * 100).toFixed(1)}% baseline. Lift marker at ${(lifted * 100).toFixed(1)}%. Range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
@@ -81,7 +81,7 @@ export function BaselineDistributionWidget() {
     setBaseline(next);
     const sd = binomialSD(CH2_N, next) / CH2_N;
     const lo = Math.max(0, (next - 2 * sd) * 100);
-    const hi = Math.min(35, (next + 2 * sd) * 100);
+    const hi = Math.min(CH2_AXIS_MAX * 100, (next + 2 * sd) * 100);
     const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
     setLiveText(
       `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Redrawing. Expected range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
@@ -90,7 +90,7 @@ export function BaselineDistributionWidget() {
 
   const sd = binomialSD(CH2_N, baseline) / CH2_N;
   const lo = Math.max(0, (baseline - 2 * sd) * 100);
-  const hi = Math.min(35, (baseline + 2 * sd) * 100);
+  const hi = Math.min(CH2_AXIS_MAX * 100, (baseline + 2 * sd) * 100);
   const liftPoints = baseline * CH2_LIFT * 100;
   const liftLabel = `+${(CH2_LIFT * 100).toFixed(0)}%`;
 

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { drawSample, countSample, binomialSD } from "@/maths/sampling";
+import { SamplingRateDistribution } from "./sampling-rate-distribution";
+import {
+  CH2_BASELINE_MIN,
+  CH2_BASELINE_MAX,
+  CH2_BASELINE_DEFAULT,
+  CH2_N,
+  CH2_SAMPLE_COUNT,
+  CH2_STAGGER_MS,
+  CH2_DEBOUNCE_MS,
+} from "./chapter-2-constants";
+
+export function BaselineDistributionWidget() {
+  const [baseline, setBaseline] = useState(CH2_BASELINE_DEFAULT);
+  const [rates, setRates] = useState<number[]>([]);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [hasDrawn, setHasDrawn] = useState(false);
+  const [liveText, setLiveText] = useState("");
+
+  const drawTimeouts = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const triggerDraw = useCallback(
+    (currentBaseline: number) => {
+      if (isDrawing) return;
+      setIsDrawing(true);
+      setRates([]);
+
+      const computed = Array.from({ length: CH2_SAMPLE_COUNT }, () => {
+        const marbles = drawSample(CH2_N, currentBaseline);
+        return countSample(marbles) / CH2_N;
+      });
+
+      const timeouts: ReturnType<typeof setTimeout>[] = [];
+      computed.forEach((rate, i) => {
+        const t = setTimeout(() => {
+          setRates((prev) => [...prev, rate]);
+          if (i === computed.length - 1) {
+            setIsDrawing(false);
+            setHasDrawn(true);
+            const sd = binomialSD(CH2_N, currentBaseline) / CH2_N;
+            const lo = Math.max(0, (currentBaseline - 2 * sd) * 100);
+            const hi = Math.min(35, (currentBaseline + 2 * sd) * 100);
+            setLiveText(
+              `Drew 100 samples at ${(currentBaseline * 100).toFixed(1)}% baseline, ranging from ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
+            );
+          }
+        }, i * CH2_STAGGER_MS);
+        timeouts.push(t);
+      });
+
+      drawTimeouts.current = timeouts;
+    },
+    [isDrawing],
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => triggerDraw(baseline), CH2_DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseline]);
+
+  useEffect(() => {
+    return () => {
+      drawTimeouts.current.forEach(clearTimeout);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const handleBaselineChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = Number(e.target.value) / 100;
+    setBaseline(next);
+    const sd = binomialSD(CH2_N, next) / CH2_N;
+    const lo = Math.max(0, (next - 2 * sd) * 100);
+    const hi = Math.min(35, (next + 2 * sd) * 100);
+    setLiveText(
+      `Baseline changed to ${(next * 100).toFixed(1)}%; redrawing. Expected range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
+    );
+  };
+
+  const sd = binomialSD(CH2_N, baseline) / CH2_N;
+  const lo = Math.max(0, (baseline - 2 * sd) * 100);
+  const hi = Math.min(35, (baseline + 2 * sd) * 100);
+  const spread = hi - lo;
+
+  let insightText: string;
+  if (baseline <= 0.03) {
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a sample of 100 could show anywhere from ${lo.toFixed(0)}% to ${hi.toFixed(0)}%. That's a spread of ${spread.toFixed(1)} points — more than double the truth itself.`;
+  } else if (baseline <= 0.1) {
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, your sample will land roughly between ${lo.toFixed(0)}% and ${hi.toFixed(0)}%. You can tell broad differences apart, not small ones.`;
+  } else {
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, your sample will land within ~${(spread / 2).toFixed(1)} points of the truth. That's tight enough to spot a real change.`;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div className="flex w-full max-w-[560px] items-center gap-4">
+        <label className="shrink-0 text-sm font-medium text-foreground/70">
+          Baseline:
+        </label>
+        <input
+          type="range"
+          min={CH2_BASELINE_MIN * 100}
+          max={CH2_BASELINE_MAX * 100}
+          step={0.5}
+          value={baseline * 100}
+          onChange={handleBaselineChange}
+          aria-label="Baseline conversion rate"
+          aria-valuetext={`${(baseline * 100).toFixed(1)}%`}
+          className="flex-1"
+        />
+        <span className="w-12 shrink-0 text-right text-sm font-semibold tabular-nums text-foreground/80">
+          {(baseline * 100).toFixed(1)}%
+        </span>
+      </div>
+
+      <SamplingRateDistribution rates={rates} baseline={baseline} />
+
+      <button
+        onClick={() => triggerDraw(baseline)}
+        disabled={isDrawing}
+        className="rounded-md bg-foreground/8 px-4 py-2 text-sm font-medium text-foreground/70 transition hover:bg-foreground/12 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {hasDrawn ? "Redraw" : "Draw 100 samples"}
+      </button>
+
+      <p className="max-w-[480px] text-center text-sm text-foreground/60">
+        {insightText}
+      </p>
+
+      <div aria-live="polite" className="sr-only">
+        {liveText}
+      </div>
+    </div>
+  );
+}

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -35,8 +35,9 @@ function buildTheoreticalBuckets({
   }
 
   // Binomial PMF via recurrence to avoid huge binomial coefficients.
-  // We first compute raw weights per visible bin, then allocate exactly totalDots
-  // using a largest-remainder method. This avoids rounding drift.
+  // We first compute raw weights per visible bin, then renormalize to exactly
+  // totalDots using a largest-remainder method. This gives stable visual density
+  // regardless of how much probability mass falls outside maxBin.
   const raw = Array.from({ length: maxBin + 1 }, () => 0);
 
   // P(K=0) = (1-p)^n
@@ -44,8 +45,8 @@ function buildTheoreticalBuckets({
   for (let k = 0; k <= n; k += 1) {
     const ratePct = Math.round((k / n) * 100);
     if (ratePct <= maxBin) raw[ratePct] += prob;
-    // out-of-range outcomes are silently dropped; we scale against the full
-    // probability mass (1.0) below so visible bins stay proportionally faithful.
+    // out-of-range outcomes are silently dropped; visibleMass renormalization
+    // below ensures the visible bins always sum to totalDots.
 
     // P(K=k+1) = P(K=k) * (n-k)/(k+1) * p/(1-p)
     if (k < n) {
@@ -60,11 +61,10 @@ function buildTheoreticalBuckets({
     return buckets;
   }
 
-  // Scale against 1.0 (full probability), not visibleMass, so that each bin
-  // reflects its true share of totalDots and overflow tails don't spike the edge.
-  const scaled = raw.map((v) => v * totalDots);
+  // Renormalize against visibleMass so buckets always sum to exactly totalDots.
+  const scaled = raw.map((v) => (v / visibleMass) * totalDots);
   const floored = scaled.map((v) => Math.floor(v));
-  let remaining = Math.round(visibleMass * totalDots) - floored.reduce((acc, v) => acc + v, 0);
+  let remaining = totalDots - floored.reduce((acc, v) => acc + v, 0);
 
   const remainders = scaled
     .map((v, idx) => ({ idx, frac: v - Math.floor(v) }))

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -7,6 +7,8 @@ import {
   CH2_BASELINE_MIN,
   CH2_BASELINE_MAX,
   CH2_BASELINE_DEFAULT,
+  CH2_AXIS_MAX,
+  CH2_LIFT,
   CH2_N,
   CH2_SAMPLE_COUNT,
   CH2_STAGGER_MS,
@@ -44,8 +46,9 @@ export function BaselineDistributionWidget() {
             const sd = binomialSD(CH2_N, currentBaseline) / CH2_N;
             const lo = Math.max(0, (currentBaseline - 2 * sd) * 100);
             const hi = Math.min(35, (currentBaseline + 2 * sd) * 100);
+            const lifted = Math.min(CH2_AXIS_MAX, currentBaseline * (1 + CH2_LIFT));
             setLiveText(
-              `Drew 100 samples at ${(currentBaseline * 100).toFixed(1)}% baseline, ranging from ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
+              `Drew 100 samples at ${(currentBaseline * 100).toFixed(1)}% baseline. Lift marker at ${(lifted * 100).toFixed(1)}%. Range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
             );
           }
         }, i * CH2_STAGGER_MS);
@@ -79,23 +82,25 @@ export function BaselineDistributionWidget() {
     const sd = binomialSD(CH2_N, next) / CH2_N;
     const lo = Math.max(0, (next - 2 * sd) * 100);
     const hi = Math.min(35, (next + 2 * sd) * 100);
+    const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
     setLiveText(
-      `Baseline changed to ${(next * 100).toFixed(1)}%; redrawing. Expected range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
+      `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Redrawing. Expected range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
     );
   };
 
   const sd = binomialSD(CH2_N, baseline) / CH2_N;
   const lo = Math.max(0, (baseline - 2 * sd) * 100);
   const hi = Math.min(35, (baseline + 2 * sd) * 100);
-  const spread = hi - lo;
+  const liftPoints = baseline * CH2_LIFT * 100;
+  const liftLabel = `+${(CH2_LIFT * 100).toFixed(0)}%`;
 
   let insightText: string;
   if (baseline <= 0.03) {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a sample of 100 could show anywhere from ${lo.toFixed(0)}% to ${hi.toFixed(0)}%. That's a spread of ${spread.toFixed(1)} points — more than double the truth itself.`;
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a ${liftLabel} lift is only ~${liftPoints.toFixed(1)} points. That's buried inside the usual wobble of a 100-visitor sample (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
   } else if (baseline <= 0.1) {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, your sample will land roughly between ${lo.toFixed(0)}% and ${hi.toFixed(0)}%. You can tell broad differences apart, not small ones.`;
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, the lift line moves by ~${liftPoints.toFixed(1)} points, but single samples still bounce around (${lo.toFixed(0)}%–${hi.toFixed(0)}%). You can tell broad differences apart, not small ones.`;
   } else {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, your sample will land within ~${(spread / 2).toFixed(1)} points of the truth. That's tight enough to spot a real change.`;
+    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a ${liftLabel} lift is ~${liftPoints.toFixed(1)} points, so the two averages separate on the axis. But a single 100-visitor sample still varies by a few points (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
   }
 
   return (

--- a/components/tutorial/baseline-distribution-widget.tsx
+++ b/components/tutorial/baseline-distribution-widget.tsx
@@ -1,92 +1,138 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { drawSample, countSample, binomialSD } from "@/maths/sampling";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { binomialSD } from "@/maths/sampling";
 import { SamplingRateDistribution } from "./sampling-rate-distribution";
 import {
-  CH2_BASELINE_MIN,
-  CH2_BASELINE_MAX,
   CH2_BASELINE_DEFAULT,
+  CH2_BASELINE_STEPS,
   CH2_AXIS_MAX,
   CH2_LIFT,
   CH2_N,
-  CH2_SAMPLE_COUNT,
-  CH2_STAGGER_MS,
   CH2_DEBOUNCE_MS,
+  CH2_THEORY_DOT_COUNT,
 } from "./chapter-2-constants";
+
+function buildTheoreticalBuckets({
+  n,
+  p,
+  maxBin,
+  totalDots,
+}: {
+  n: number;
+  p: number;
+  maxBin: number;
+  totalDots: number;
+}) {
+  const buckets = Array.from({ length: maxBin + 1 }, () => 0);
+  if (p <= 0) {
+    buckets[0] = totalDots;
+    return buckets;
+  }
+  if (p >= 1) {
+    buckets[maxBin] = totalDots;
+    return buckets;
+  }
+
+  // Binomial PMF via recurrence to avoid huge binomial coefficients.
+  // We first compute raw weights per visible bin, then allocate exactly totalDots
+  // using a largest-remainder method. This avoids rounding drift.
+  const raw = Array.from({ length: maxBin + 1 }, () => 0);
+
+  // P(K=0) = (1-p)^n
+  let prob = Math.pow(1 - p, n);
+  for (let k = 0; k <= n; k += 1) {
+    const ratePct = Math.round((k / n) * 100);
+    if (ratePct >= 0 && ratePct <= maxBin) {
+      raw[ratePct] += prob;
+    }
+
+    // P(K=k+1) = P(K=k) * (n-k)/(k+1) * p/(1-p)
+    if (k < n) {
+      prob = (prob * (n - k)) / (k + 1);
+      prob = (prob * p) / (1 - p);
+    }
+  }
+
+  const rawSum = raw.reduce((acc, v) => acc + v, 0);
+  if (rawSum <= 0) {
+    buckets[Math.min(maxBin, Math.max(0, Math.round(p * 100)))] = totalDots;
+    return buckets;
+  }
+
+  const scaled = raw.map((v) => (v / rawSum) * totalDots);
+  const floored = scaled.map((v) => Math.floor(v));
+  let remaining = totalDots - floored.reduce((acc, v) => acc + v, 0);
+
+  const remainders = scaled
+    .map((v, idx) => ({ idx, frac: v - Math.floor(v) }))
+    .sort((a, b) => b.frac - a.frac);
+
+  for (let i = 0; i < remainders.length && remaining > 0; i += 1) {
+    floored[remainders[i].idx] += 1;
+    remaining -= 1;
+  }
+
+  for (let i = 0; i < buckets.length; i += 1) {
+    buckets[i] = floored[i];
+  }
+
+  return buckets;
+}
 
 export function BaselineDistributionWidget() {
   const [baseline, setBaseline] = useState(CH2_BASELINE_DEFAULT);
-  const [rates, setRates] = useState<number[]>([]);
-  const [isDrawing, setIsDrawing] = useState(false);
-  const [hasDrawn, setHasDrawn] = useState(false);
   const [liveText, setLiveText] = useState("");
-
-  const drawTimeouts = useRef<ReturnType<typeof setTimeout>[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const triggerDraw = useCallback(
-    (currentBaseline: number) => {
-      if (isDrawing) return;
-      setIsDrawing(true);
-      setRates([]);
+  const baselineIndex = useMemo(() => {
+    const exact = CH2_BASELINE_STEPS.indexOf(baseline as (typeof CH2_BASELINE_STEPS)[number]);
+    if (exact !== -1) return exact;
 
-      const computed = Array.from({ length: CH2_SAMPLE_COUNT }, () => {
-        const marbles = drawSample(CH2_N, currentBaseline);
-        return countSample(marbles) / CH2_N;
-      });
-
-      const timeouts: ReturnType<typeof setTimeout>[] = [];
-      computed.forEach((rate, i) => {
-        const t = setTimeout(() => {
-          setRates((prev) => [...prev, rate]);
-          if (i === computed.length - 1) {
-            setIsDrawing(false);
-            setHasDrawn(true);
-            const sd = binomialSD(CH2_N, currentBaseline) / CH2_N;
-            const lo = Math.max(0, (currentBaseline - 2 * sd) * 100);
-            const hi = Math.min(CH2_AXIS_MAX * 100, (currentBaseline + 2 * sd) * 100);
-            const lifted = Math.min(CH2_AXIS_MAX, currentBaseline * (1 + CH2_LIFT));
-            setLiveText(
-              `Drew 100 samples at ${(currentBaseline * 100).toFixed(1)}% baseline. Lift marker at ${(lifted * 100).toFixed(1)}%. Range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
-            );
-          }
-        }, i * CH2_STAGGER_MS);
-        timeouts.push(t);
-      });
-
-      drawTimeouts.current = timeouts;
-    },
-    [isDrawing],
-  );
-
-  useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => triggerDraw(baseline), CH2_DEBOUNCE_MS);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    let bestIdx = 0;
+    let bestDist = Infinity;
+    for (let i = 0; i < CH2_BASELINE_STEPS.length; i += 1) {
+      const dist = Math.abs(CH2_BASELINE_STEPS[i] - baseline);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i;
+      }
+    }
+    return bestIdx;
   }, [baseline]);
 
   useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    const next = baseline;
+    debounceRef.current = setTimeout(() => {
+      const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
+      setLiveText(
+        `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Showing the theoretical distribution for 100 visitors.`,
+      );
+    }, CH2_DEBOUNCE_MS);
     return () => {
-      drawTimeouts.current.forEach(clearTimeout);
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, []);
+  }, [baseline]);
 
   const handleBaselineChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const next = Number(e.target.value) / 100;
+    const idx = Number(e.target.value);
+    const next = CH2_BASELINE_STEPS[Math.min(CH2_BASELINE_STEPS.length - 1, Math.max(0, idx))];
     setBaseline(next);
-    const sd = binomialSD(CH2_N, next) / CH2_N;
-    const lo = Math.max(0, (next - 2 * sd) * 100);
-    const hi = Math.min(CH2_AXIS_MAX * 100, (next + 2 * sd) * 100);
     const lifted = Math.min(CH2_AXIS_MAX, next * (1 + CH2_LIFT));
     setLiveText(
-      `Baseline changed to ${(next * 100).toFixed(1)}%. Lift marker at ${(lifted * 100).toFixed(1)}%. Redrawing. Expected range ${lo.toFixed(0)}% to ${hi.toFixed(0)}%.`,
+      `Baseline changed to ${(next * 100).toFixed(0)}%. Lift marker at ${(lifted * 100).toFixed(1)}%.`,
     );
   };
+
+  const theoryBuckets = useMemo(() => {
+    return buildTheoreticalBuckets({
+      n: CH2_N,
+      p: baseline,
+      maxBin: Math.round(CH2_AXIS_MAX * 100),
+      totalDots: CH2_THEORY_DOT_COUNT,
+    });
+  }, [baseline]);
 
   const sd = binomialSD(CH2_N, baseline) / CH2_N;
   const lo = Math.max(0, (baseline - 2 * sd) * 100);
@@ -96,11 +142,11 @@ export function BaselineDistributionWidget() {
 
   let insightText: string;
   if (baseline <= 0.03) {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a ${liftLabel} lift is only ~${liftPoints.toFixed(1)} points. That's buried inside the usual wobble of a 100-visitor sample (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
+    insightText = `At ${(baseline * 100).toFixed(0)}% baseline, a ${liftLabel} lift is only ~${liftPoints.toFixed(1)} points. That's buried inside the usual wobble of a 100-visitor sample (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
   } else if (baseline <= 0.1) {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, the lift line moves by ~${liftPoints.toFixed(1)} points, but single samples still bounce around (${lo.toFixed(0)}%–${hi.toFixed(0)}%). You can tell broad differences apart, not small ones.`;
+    insightText = `At ${(baseline * 100).toFixed(0)}% baseline, the lift line moves by ~${liftPoints.toFixed(1)} points, but single samples still bounce around (${lo.toFixed(0)}%–${hi.toFixed(0)}%). You can tell broad differences apart, not small ones.`;
   } else {
-    insightText = `At ${(baseline * 100).toFixed(1)}% baseline, a ${liftLabel} lift is ~${liftPoints.toFixed(1)} points, so the two averages separate on the axis. But a single 100-visitor sample still varies by a few points (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
+    insightText = `At ${(baseline * 100).toFixed(0)}% baseline, a ${liftLabel} lift is ~${liftPoints.toFixed(1)} points, so the two averages separate on the axis. But a single 100-visitor sample still varies by a few points (${lo.toFixed(0)}%–${hi.toFixed(0)}%).`;
   }
 
   return (
@@ -111,29 +157,21 @@ export function BaselineDistributionWidget() {
         </label>
         <input
           type="range"
-          min={CH2_BASELINE_MIN * 100}
-          max={CH2_BASELINE_MAX * 100}
-          step={0.5}
-          value={baseline * 100}
+          min={0}
+          max={CH2_BASELINE_STEPS.length - 1}
+          step={1}
+          value={baselineIndex}
           onChange={handleBaselineChange}
           aria-label="Baseline conversion rate"
-          aria-valuetext={`${(baseline * 100).toFixed(1)}%`}
+          aria-valuetext={`${(baseline * 100).toFixed(0)}%`}
           className="flex-1"
         />
         <span className="w-12 shrink-0 text-right text-sm font-semibold tabular-nums text-foreground/80">
-          {(baseline * 100).toFixed(1)}%
+          {(baseline * 100).toFixed(0)}%
         </span>
       </div>
 
-      <SamplingRateDistribution rates={rates} baseline={baseline} />
-
-      <button
-        onClick={() => triggerDraw(baseline)}
-        disabled={isDrawing}
-        className="rounded-md bg-foreground/8 px-4 py-2 text-sm font-medium text-foreground/70 transition hover:bg-foreground/12 disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        {hasDrawn ? "Redraw" : "Draw 100 samples"}
-      </button>
+      <SamplingRateDistribution buckets={theoryBuckets} baseline={baseline} />
 
       <p className="max-w-[480px] text-center text-sm text-foreground/60">
         {insightText}

--- a/components/tutorial/chapter-2-constants.ts
+++ b/components/tutorial/chapter-2-constants.ts
@@ -1,10 +1,10 @@
-export const CH2_BASELINE_MIN     = 0.01;
-export const CH2_BASELINE_MAX     = 0.25;
+export const CH2_BASELINE_MIN = 0.01;
+export const CH2_BASELINE_MAX = 0.50;
 export const CH2_BASELINE_DEFAULT = 0.05;
-export const CH2_N                = 100;
-export const CH2_SAMPLE_COUNT     = 100;
-export const CH2_AXIS_MAX         = 0.35;
-export const CH2_STAGGER_MS       = 10;
-export const CH2_DEBOUNCE_MS      = 120;
-export const CH2_LIFT             = 0.10;  // 10% relative lift scenario
+export const CH2_N = 100;
+export const CH2_SAMPLE_COUNT = 100;
+export const CH2_AXIS_MAX = 0.60;
+export const CH2_STAGGER_MS = 10;
+export const CH2_DEBOUNCE_MS = 120;
+export const CH2_LIFT = 0.10;  // 10% relative lift scenario
 

--- a/components/tutorial/chapter-2-constants.ts
+++ b/components/tutorial/chapter-2-constants.ts
@@ -1,0 +1,10 @@
+export const CH2_BASELINE_MIN     = 0.01;
+export const CH2_BASELINE_MAX     = 0.25;
+export const CH2_BASELINE_DEFAULT = 0.05;
+export const CH2_N                = 100;
+export const CH2_SAMPLE_COUNT     = 100;
+export const CH2_AXIS_MAX         = 0.35;
+export const CH2_STAGGER_MS       = 10;
+export const CH2_DEBOUNCE_MS      = 120;
+export const CH2_LIFT             = 0.10;  // 10% relative lift scenario
+

--- a/components/tutorial/chapter-2-constants.ts
+++ b/components/tutorial/chapter-2-constants.ts
@@ -1,8 +1,10 @@
 export const CH2_BASELINE_MIN = 0.01;
 export const CH2_BASELINE_MAX = 0.50;
 export const CH2_BASELINE_DEFAULT = 0.05;
+export const CH2_BASELINE_STEPS = [0.01, 0.02, 0.05, 0.10, 0.20, 0.30, 0.40, 0.50] as const;
 export const CH2_N = 100;
 export const CH2_SAMPLE_COUNT = 100;
+export const CH2_THEORY_DOT_COUNT = 400;
 export const CH2_AXIS_MAX = 0.60;
 export const CH2_STAGGER_MS = 10;
 export const CH2_DEBOUNCE_MS = 120;

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -92,7 +92,11 @@ export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         preserveAspectRatio="xMidYMid meet"
         role="img"
-        aria-label={`Theoretical sampling distribution at ${baselinePct.toFixed(1)}% baseline (N=${CH2_N}), with a ${liftLabel} marker.`}
+        aria-label={
+          rates
+            ? `Empirical sampling distribution from ${rates.length} draws at ${baselinePct.toFixed(1)}% baseline, with a ${liftLabel} marker.`
+            : `Theoretical sampling distribution at ${baselinePct.toFixed(1)}% baseline (N=${CH2_N}), with a ${liftLabel} marker.`
+        }
         className="block h-auto w-full"
       >
         <Group left={MARGIN.left} top={MARGIN.top}>

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -3,11 +3,11 @@
 import { AxisBottom, AxisLeft } from "@visx/axis";
 import { Group } from "@visx/group";
 import { scaleBand, scaleLinear } from "@visx/scale";
-import { binomialSD } from "@/maths/sampling";
 import { CH2_AXIS_MAX, CH2_LIFT, CH2_N } from "./chapter-2-constants";
 
 type Props = {
-  rates: number[];
+  rates?: number[];
+  buckets?: number[];
   baseline: number;
 };
 
@@ -18,8 +18,7 @@ const PLOT_W = WIDTH - MARGIN.left - MARGIN.right;
 const PLOT_H = HEIGHT - MARGIN.top - MARGIN.bottom;
 const DOT_R_NOMINAL = 4;
 const DOT_STEP_NOMINAL = 10;
-const PLACEHOLDER_ROWS = 3;
-const MAX_BIN = Math.round(CH2_AXIS_MAX * 100); // 35
+const MAX_BIN = Math.round(CH2_AXIS_MAX * 100);
 
 const axisLabelProps = {
   fill: "currentColor",
@@ -35,16 +34,22 @@ function buildTickValues(maxBin: number, interval: number) {
   return ticks;
 }
 
-export function SamplingRateDistribution({ rates, baseline }: Props) {
+export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
   const cols = Array.from({ length: MAX_BIN + 1 }, (_, i) => i);
   const xTicks = buildTickValues(MAX_BIN, 10);
-  const buckets = cols.map(() => 0);
-  for (const r of rates) {
-    const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
-    buckets[bin] += 1;
+  const bucketCounts = cols.map(() => 0);
+  if (buckets) {
+    for (let i = 0; i < bucketCounts.length; i += 1) {
+      bucketCounts[i] = Math.max(0, Math.floor(buckets[i] ?? 0));
+    }
+  } else if (rates) {
+    for (const r of rates) {
+      const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
+      bucketCounts[bin] += 1;
+    }
   }
 
-  const maxBucket = Math.max(1, ...buckets);
+  const maxBucket = Math.max(1, ...bucketCounts);
   const maxDotsNominal = Math.floor(PLOT_H / DOT_STEP_NOMINAL);
   const scale = maxBucket <= maxDotsNominal ? 1 : maxDotsNominal / maxBucket;
   const step = DOT_STEP_NOMINAL * scale;
@@ -66,26 +71,20 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
     (_, i) => i * tickInterval,
   );
 
-  const sd = binomialSD(CH2_N, baseline) / CH2_N;
-  const loFrac = Math.max(0, baseline - 2 * sd);
-  const hiFrac = Math.min(CH2_AXIS_MAX, baseline + 2 * sd);
-  const loBin = Math.round(loFrac * 100);
-  const hiBin = Math.round(hiFrac * 100);
-
-  const bandLeft = xScale(loBin) ?? 0;
-  const bandRight = (xScale(hiBin) ?? 0) + xScale.bandwidth();
-
   const baselinePct = baseline * 100;
   const lifted = Math.min(CH2_AXIS_MAX, baseline * (1 + CH2_LIFT));
   const liftedPct = lifted * 100;
   const baselineBin = Math.round(baselinePct);
   const liftLabel = `+${(CH2_LIFT * 100).toFixed(0)}% lift: ${liftedPct.toFixed(1)}%`;
 
-  const columnCounters = cols.map(() => 0);
-  const dots = rates.flatMap((r, idx) => {
-    const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
-    return [{ key: idx, col: bin, row: columnCounters[bin]++ }];
-  });
+  const dots: Array<{ key: string; col: number; row: number }> = [];
+  for (const col of cols) {
+    const count = bucketCounts[col] ?? 0;
+    for (let row = 0; row < count; row += 1) {
+      dots.push({ key: `${col}-${row}`, col, row });
+    }
+  }
+  const dotTotal = dots.length;
 
   return (
     <div className="flex w-full max-w-[560px] flex-col items-center gap-2">
@@ -93,31 +92,10 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         preserveAspectRatio="xMidYMid meet"
         role="img"
-        aria-label={`Sampling rate distribution of ${rates.length} draws at ${baselinePct.toFixed(1)}% baseline, with a ${liftLabel} marker, ranging from ${(loFrac * 100).toFixed(0)}% to ${(hiFrac * 100).toFixed(0)}%.`}
+        aria-label={`Theoretical sampling distribution at ${baselinePct.toFixed(1)}% baseline (N=${CH2_N}), with a ${liftLabel} marker.`}
         className="block h-auto w-full"
       >
         <Group left={MARGIN.left} top={MARGIN.top}>
-          {/* ±2σ band */}
-          <rect
-            x={bandLeft}
-            y={0}
-            width={Math.max(0, bandRight - bandLeft)}
-            height={PLOT_H}
-            fill="currentColor"
-            fillOpacity={0.05}
-          />
-          <text
-            x={bandRight - 4}
-            y={8}
-            textAnchor="end"
-            fontSize="9"
-            fontWeight={500}
-            fill="currentColor"
-            fillOpacity={0.3}
-          >
-            typical range
-          </text>
-
           <AxisLeft
             scale={yScale}
             tickValues={yTicks}
@@ -126,7 +104,7 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             tickStroke="currentColor"
             tickClassName="[stroke-opacity:0.25]"
             tickLength={4}
-            label="times drawn"
+            label="relative likelihood"
             labelOffset={24}
             labelProps={{ ...axisLabelProps, textAnchor: "middle" }}
             tickLabelProps={() => ({
@@ -179,14 +157,14 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
           />
           <text
             x={xValueScale(baselinePct)}
-            y={-12}
+            y={-24}
             textAnchor="middle"
             fontSize="10"
             fontWeight="600"
             fill="currentColor"
             fillOpacity={0.55}
           >
-            average: {baselinePct.toFixed(1)}%
+            average: {baselinePct.toFixed(0)}%
           </text>
 
           {/* Lift marker line */}
@@ -195,45 +173,26 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             y1={-6}
             x2={xValueScale(liftedPct)}
             y2={PLOT_H}
-            stroke="#16a34a"
+            stroke="currentColor"
             strokeOpacity={0.75}
             strokeDasharray="6 2"
             strokeWidth={1.5}
+            className="text-blue-500 dark:text-blue-400"
           />
           <text
             x={xValueScale(liftedPct)}
-            y={-24}
+            y={-12}
             textAnchor="middle"
             fontSize="10"
             fontWeight="600"
-            fill="#16a34a"
+            fill="currentColor"
             fillOpacity={0.8}
+            className="text-blue-500 dark:text-blue-400"
           >
             {liftLabel}
           </text>
 
-          {/* Placeholder slots */}
-          {cols.map((col) =>
-            Array.from({ length: PLACEHOLDER_ROWS }, (_, k) => {
-              const cy = dotCy(buckets[col] + k);
-              if (cy < 0) return null;
-              return (
-                <circle
-                  key={`ph-${col}-${k}`}
-                  cx={colX(col)}
-                  cy={cy}
-                  r={dotR}
-                  fill="none"
-                  stroke="currentColor"
-                  strokeOpacity={0.12 - k * 0.03}
-                  strokeDasharray="2 2"
-                  strokeWidth={1}
-                />
-              );
-            }),
-          )}
-
-          {/* Drawn samples as stacked dots */}
+          {/* Stacked dots */}
           {dots.map((d) => (
             <circle
               key={d.key}
@@ -241,17 +200,17 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
               cy={dotCy(d.row)}
               r={dotR}
               fill="#16a34a"
-              className="animate-dot-drop"
-              style={{ transformBox: "fill-box" as const }}
             />
           ))}
         </Group>
       </svg>
 
       <div className="text-[11px] text-foreground/45 tabular-nums">
-        {rates.length === 0
-          ? "Draw samples to begin."
-          : `${rates.length} sample${rates.length !== 1 ? "s" : ""} drawn`}
+        {dotTotal === 0
+          ? ""
+          : buckets
+            ? "Theoretical shape (not a random draw)."
+            : "Empirical draws."}
       </div>
     </div>
   );

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -4,7 +4,7 @@ import { AxisBottom, AxisLeft } from "@visx/axis";
 import { Group } from "@visx/group";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { binomialSD } from "@/maths/sampling";
-import { CH2_N, CH2_AXIS_MAX } from "./chapter-2-constants";
+import { CH2_AXIS_MAX, CH2_LIFT, CH2_N } from "./chapter-2-constants";
 
 type Props = {
   rates: number[];
@@ -43,6 +43,10 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
   const dotR = DOT_R_NOMINAL * Math.min(1, Math.max(0.6, scale));
 
   const xScale = scaleBand<number>({ domain: cols, range: [0, PLOT_W] });
+  const xValueScale = scaleLinear<number>({
+    domain: [-0.5, MAX_BIN + 0.5],
+    range: [0, PLOT_W],
+  });
   const yScale = scaleLinear<number>({ domain: [0, maxBucket], range: [PLOT_H, 0] });
   const colX = (col: number) => (xScale(col) ?? 0) + xScale.bandwidth() / 2;
   const dotCy = (row: number) => PLOT_H - dotR - row * step;
@@ -63,7 +67,11 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
   const bandLeft = xScale(loBin) ?? 0;
   const bandRight = (xScale(hiBin) ?? 0) + xScale.bandwidth();
 
-  const trueBin = Math.round(baseline * 100);
+  const baselinePct = baseline * 100;
+  const lifted = Math.min(CH2_AXIS_MAX, baseline * (1 + CH2_LIFT));
+  const liftedPct = lifted * 100;
+  const baselineBin = Math.round(baselinePct);
+  const liftLabel = `+${(CH2_LIFT * 100).toFixed(0)}% lift: ${liftedPct.toFixed(1)}%`;
 
   const columnCounters = cols.map(() => 0);
   const dots = rates.flatMap((r, idx) => {
@@ -77,7 +85,7 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         preserveAspectRatio="xMidYMid meet"
         role="img"
-        aria-label={`Sampling rate distribution of ${rates.length} draws at ${(baseline * 100).toFixed(1)}% baseline, ranging from ${(loFrac * 100).toFixed(0)}% to ${(hiFrac * 100).toFixed(0)}%.`}
+        aria-label={`Sampling rate distribution of ${rates.length} draws at ${baselinePct.toFixed(1)}% baseline, with a ${liftLabel} marker, ranging from ${(loFrac * 100).toFixed(0)}% to ${(hiFrac * 100).toFixed(0)}%.`}
         className="block h-auto w-full"
       >
         <Group left={MARGIN.left} top={MARGIN.top}>
@@ -99,7 +107,7 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             fill="currentColor"
             fillOpacity={0.3}
           >
-            ~95% of samples
+            typical range
           </text>
 
           <AxisLeft
@@ -131,9 +139,9 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             tickFormat={(v) => `${v}%`}
             tickLabelProps={(col) => ({
               fontSize: 11,
-              fontWeight: col === trueBin ? 600 : 500,
+              fontWeight: col === baselineBin ? 600 : 500,
               fill: "currentColor",
-              fillOpacity: col === trueBin ? 0.7 : 0.4,
+              fillOpacity: col === baselineBin ? 0.7 : 0.4,
               textAnchor: "middle",
               dy: "0.9em",
             })}
@@ -150,11 +158,11 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             Observed conversion rate per sample
           </text>
 
-          {/* True baseline line */}
+          {/* Baseline average line */}
           <line
-            x1={colX(trueBin)}
+            x1={xValueScale(baselinePct)}
             y1={-6}
-            x2={colX(trueBin)}
+            x2={xValueScale(baselinePct)}
             y2={PLOT_H}
             stroke="currentColor"
             strokeOpacity={0.3}
@@ -162,7 +170,7 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             strokeWidth={1}
           />
           <text
-            x={colX(trueBin)}
+            x={xValueScale(baselinePct)}
             y={-12}
             textAnchor="middle"
             fontSize="10"
@@ -170,7 +178,30 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             fill="currentColor"
             fillOpacity={0.55}
           >
-            truth: {(baseline * 100).toFixed(1)}%
+            average: {baselinePct.toFixed(1)}%
+          </text>
+
+          {/* Lift marker line */}
+          <line
+            x1={xValueScale(liftedPct)}
+            y1={-6}
+            x2={xValueScale(liftedPct)}
+            y2={PLOT_H}
+            stroke="#16a34a"
+            strokeOpacity={0.75}
+            strokeDasharray="6 2"
+            strokeWidth={1.5}
+          />
+          <text
+            x={xValueScale(liftedPct)}
+            y={-24}
+            textAnchor="middle"
+            fontSize="10"
+            fontWeight="600"
+            fill="#16a34a"
+            fillOpacity={0.8}
+          >
+            {liftLabel}
           </text>
 
           {/* Placeholder slots */}

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -129,7 +129,7 @@ export function SamplingRateDistribution({ buckets, baseline }: Props) {
             fill="currentColor"
             fillOpacity={0.4}
           >
-            Observed conversion rate per sample
+            Conversion rate per 100-visitor sample
           </text>
 
           {/* Baseline average line */}

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -28,8 +28,16 @@ const axisLabelProps = {
   fontWeight: 500,
 };
 
+function buildTickValues(maxBin: number, interval: number) {
+  const ticks: number[] = [];
+  for (let v = 0; v <= maxBin; v += interval) ticks.push(v);
+  if (ticks[ticks.length - 1] !== maxBin) ticks.push(maxBin);
+  return ticks;
+}
+
 export function SamplingRateDistribution({ rates, baseline }: Props) {
   const cols = Array.from({ length: MAX_BIN + 1 }, (_, i) => i);
+  const xTicks = buildTickValues(MAX_BIN, 10);
   const buckets = cols.map(() => 0);
   for (const r of rates) {
     const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
@@ -135,7 +143,7 @@ export function SamplingRateDistribution({ rates, baseline }: Props) {
             stroke="currentColor"
             axisLineClassName="[stroke-opacity:0.14]"
             hideTicks
-            tickValues={[0, 5, 10, 15, 20, 25, 30, 35]}
+            tickValues={xTicks}
             tickFormat={(v) => `${v}%`}
             tickLabelProps={(col) => ({
               fontSize: 11,

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { Group } from "@visx/group";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { binomialSD } from "@/maths/sampling";
+import { CH2_N, CH2_AXIS_MAX } from "./chapter-2-constants";
+
+type Props = {
+  rates: number[];
+  baseline: number;
+};
+
+const WIDTH = 560;
+const HEIGHT = 320;
+const MARGIN = { top: 44, right: 20, bottom: 50, left: 46 };
+const PLOT_W = WIDTH - MARGIN.left - MARGIN.right;
+const PLOT_H = HEIGHT - MARGIN.top - MARGIN.bottom;
+const DOT_R_NOMINAL = 4;
+const DOT_STEP_NOMINAL = 10;
+const PLACEHOLDER_ROWS = 3;
+const MAX_BIN = Math.round(CH2_AXIS_MAX * 100); // 35
+
+const axisLabelProps = {
+  fill: "currentColor",
+  fillOpacity: 0.35,
+  fontSize: 10,
+  fontWeight: 500,
+};
+
+export function SamplingRateDistribution({ rates, baseline }: Props) {
+  const cols = Array.from({ length: MAX_BIN + 1 }, (_, i) => i);
+  const buckets = cols.map(() => 0);
+  for (const r of rates) {
+    const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
+    buckets[bin] += 1;
+  }
+
+  const maxBucket = Math.max(1, ...buckets);
+  const maxDotsNominal = Math.floor(PLOT_H / DOT_STEP_NOMINAL);
+  const scale = maxBucket <= maxDotsNominal ? 1 : maxDotsNominal / maxBucket;
+  const step = DOT_STEP_NOMINAL * scale;
+  const dotR = DOT_R_NOMINAL * Math.min(1, Math.max(0.6, scale));
+
+  const xScale = scaleBand<number>({ domain: cols, range: [0, PLOT_W] });
+  const yScale = scaleLinear<number>({ domain: [0, maxBucket], range: [PLOT_H, 0] });
+  const colX = (col: number) => (xScale(col) ?? 0) + xScale.bandwidth() / 2;
+  const dotCy = (row: number) => PLOT_H - dotR - row * step;
+
+  const tickInterval =
+    maxBucket <= 5 ? 1 : maxBucket <= 20 ? 5 : maxBucket <= 50 ? 10 : maxBucket <= 100 ? 25 : 50;
+  const yTicks = Array.from(
+    { length: Math.floor(maxBucket / tickInterval) + 1 },
+    (_, i) => i * tickInterval,
+  );
+
+  const sd = binomialSD(CH2_N, baseline) / CH2_N;
+  const loFrac = Math.max(0, baseline - 2 * sd);
+  const hiFrac = Math.min(CH2_AXIS_MAX, baseline + 2 * sd);
+  const loBin = Math.round(loFrac * 100);
+  const hiBin = Math.round(hiFrac * 100);
+
+  const bandLeft = xScale(loBin) ?? 0;
+  const bandRight = (xScale(hiBin) ?? 0) + xScale.bandwidth();
+
+  const trueBin = Math.round(baseline * 100);
+
+  const columnCounters = cols.map(() => 0);
+  const dots = rates.flatMap((r, idx) => {
+    const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
+    return [{ key: idx, col: bin, row: columnCounters[bin]++ }];
+  });
+
+  return (
+    <div className="flex w-full max-w-[560px] flex-col items-center gap-2">
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={`Sampling rate distribution of ${rates.length} draws at ${(baseline * 100).toFixed(1)}% baseline, ranging from ${(loFrac * 100).toFixed(0)}% to ${(hiFrac * 100).toFixed(0)}%.`}
+        className="block h-auto w-full"
+      >
+        <Group left={MARGIN.left} top={MARGIN.top}>
+          {/* ±2σ band */}
+          <rect
+            x={bandLeft}
+            y={0}
+            width={Math.max(0, bandRight - bandLeft)}
+            height={PLOT_H}
+            fill="currentColor"
+            fillOpacity={0.05}
+          />
+          <text
+            x={bandRight - 4}
+            y={8}
+            textAnchor="end"
+            fontSize="9"
+            fontWeight={500}
+            fill="currentColor"
+            fillOpacity={0.3}
+          >
+            ~95% of samples
+          </text>
+
+          <AxisLeft
+            scale={yScale}
+            tickValues={yTicks}
+            stroke="currentColor"
+            axisLineClassName="[stroke-opacity:0.14]"
+            tickStroke="currentColor"
+            tickClassName="[stroke-opacity:0.25]"
+            tickLength={4}
+            label="times drawn"
+            labelOffset={24}
+            labelProps={{ ...axisLabelProps, textAnchor: "middle" }}
+            tickLabelProps={() => ({
+              ...axisLabelProps,
+              textAnchor: "end",
+              dx: "-0.25em",
+              dy: "0.32em",
+            })}
+          />
+
+          <AxisBottom
+            top={PLOT_H}
+            scale={xScale}
+            stroke="currentColor"
+            axisLineClassName="[stroke-opacity:0.14]"
+            hideTicks
+            tickValues={[0, 5, 10, 15, 20, 25, 30, 35]}
+            tickFormat={(v) => `${v}%`}
+            tickLabelProps={(col) => ({
+              fontSize: 11,
+              fontWeight: col === trueBin ? 600 : 500,
+              fill: "currentColor",
+              fillOpacity: col === trueBin ? 0.7 : 0.4,
+              textAnchor: "middle",
+              dy: "0.9em",
+            })}
+          />
+          <text
+            x={PLOT_W / 2}
+            y={PLOT_H + 45}
+            textAnchor="middle"
+            fontSize="10"
+            fontWeight={500}
+            fill="currentColor"
+            fillOpacity={0.4}
+          >
+            Observed conversion rate per sample
+          </text>
+
+          {/* True baseline line */}
+          <line
+            x1={colX(trueBin)}
+            y1={-6}
+            x2={colX(trueBin)}
+            y2={PLOT_H}
+            stroke="currentColor"
+            strokeOpacity={0.3}
+            strokeDasharray="3 3"
+            strokeWidth={1}
+          />
+          <text
+            x={colX(trueBin)}
+            y={-12}
+            textAnchor="middle"
+            fontSize="10"
+            fontWeight="600"
+            fill="currentColor"
+            fillOpacity={0.55}
+          >
+            truth: {(baseline * 100).toFixed(1)}%
+          </text>
+
+          {/* Placeholder slots */}
+          {cols.map((col) =>
+            Array.from({ length: PLACEHOLDER_ROWS }, (_, k) => {
+              const cy = dotCy(buckets[col] + k);
+              if (cy < 0) return null;
+              return (
+                <circle
+                  key={`ph-${col}-${k}`}
+                  cx={colX(col)}
+                  cy={cy}
+                  r={dotR}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeOpacity={0.12 - k * 0.03}
+                  strokeDasharray="2 2"
+                  strokeWidth={1}
+                />
+              );
+            }),
+          )}
+
+          {/* Drawn samples as stacked dots */}
+          {dots.map((d) => (
+            <circle
+              key={d.key}
+              cx={colX(d.col)}
+              cy={dotCy(d.row)}
+              r={dotR}
+              fill="#16a34a"
+              className="animate-dot-drop"
+              style={{ transformBox: "fill-box" as const }}
+            />
+          ))}
+        </Group>
+      </svg>
+
+      <div className="text-[11px] text-foreground/45 tabular-nums">
+        {rates.length === 0
+          ? "Draw samples to begin."
+          : `${rates.length} sample${rates.length !== 1 ? "s" : ""} drawn`}
+      </div>
+    </div>
+  );
+}

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -6,8 +6,7 @@ import { scaleBand, scaleLinear } from "@visx/scale";
 import { CH2_AXIS_MAX, CH2_LIFT, CH2_N } from "./chapter-2-constants";
 
 type Props = {
-  rates?: number[];
-  buckets?: number[];
+  buckets: number[];
   baseline: number;
 };
 
@@ -34,20 +33,10 @@ function buildTickValues(maxBin: number, interval: number) {
   return ticks;
 }
 
-export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
+export function SamplingRateDistribution({ buckets, baseline }: Props) {
   const cols = Array.from({ length: MAX_BIN + 1 }, (_, i) => i);
   const xTicks = buildTickValues(MAX_BIN, 10);
-  const bucketCounts = cols.map(() => 0);
-  if (buckets) {
-    for (let i = 0; i < bucketCounts.length; i += 1) {
-      bucketCounts[i] = Math.max(0, Math.floor(buckets[i] ?? 0));
-    }
-  } else if (rates) {
-    for (const r of rates) {
-      const bin = Math.min(MAX_BIN, Math.max(0, Math.round(r * 100)));
-      bucketCounts[bin] += 1;
-    }
-  }
+  const bucketCounts = cols.map((_, i) => Math.max(0, Math.floor(buckets[i] ?? 0)));
 
   const maxBucket = Math.max(1, ...bucketCounts);
   const maxDotsNominal = Math.floor(PLOT_H / DOT_STEP_NOMINAL);
@@ -84,7 +73,6 @@ export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
       dots.push({ key: `${col}-${row}`, col, row });
     }
   }
-  const dotTotal = dots.length;
 
   return (
     <div className="flex w-full max-w-[560px] flex-col items-center gap-2">
@@ -92,11 +80,7 @@ export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         preserveAspectRatio="xMidYMid meet"
         role="img"
-        aria-label={
-          rates
-            ? `Empirical sampling distribution from ${rates.length} draws at ${baselinePct.toFixed(1)}% baseline, with a ${liftLabel} marker.`
-            : `Theoretical sampling distribution at ${baselinePct.toFixed(1)}% baseline (N=${CH2_N}), with a ${liftLabel} marker.`
-        }
+        aria-label={`Theoretical sampling distribution at ${baselinePct.toFixed(1)}% baseline (N=${CH2_N}), with a ${liftLabel} marker.`}
         className="block h-auto w-full"
       >
         <Group left={MARGIN.left} top={MARGIN.top}>
@@ -210,11 +194,7 @@ export function SamplingRateDistribution({ rates, buckets, baseline }: Props) {
       </svg>
 
       <div className="text-[11px] text-foreground/45 tabular-nums">
-        {dotTotal === 0
-          ? ""
-          : buckets
-            ? "Theoretical shape (not a random draw)."
-            : "Empirical draws."}
+        Theoretical shape (not a random draw).
       </div>
     </div>
   );

--- a/components/tutorial/sampling-rate-distribution.tsx
+++ b/components/tutorial/sampling-rate-distribution.tsx
@@ -35,7 +35,7 @@ function buildTickValues(maxBin: number, interval: number) {
 
 export function SamplingRateDistribution({ buckets, baseline }: Props) {
   const cols = Array.from({ length: MAX_BIN + 1 }, (_, i) => i);
-  const xTicks = buildTickValues(MAX_BIN, 10);
+  const xTicksBase = buildTickValues(MAX_BIN, 10);
   const bucketCounts = cols.map((_, i) => Math.max(0, Math.floor(buckets[i] ?? 0)));
 
   const maxBucket = Math.max(1, ...bucketCounts);
@@ -64,6 +64,7 @@ export function SamplingRateDistribution({ buckets, baseline }: Props) {
   const lifted = Math.min(CH2_AXIS_MAX, baseline * (1 + CH2_LIFT));
   const liftedPct = lifted * 100;
   const baselineBin = Math.round(baselinePct);
+  const xTicks = [...new Set([...xTicksBase, baselineBin])].sort((a, b) => a - b);
   const liftLabel = `+${(CH2_LIFT * 100).toFixed(0)}% lift: ${liftedPct.toFixed(1)}%`;
 
   const dots: Array<{ key: string; col: number; row: number }> = [];

--- a/docs/plans/06-baseline-distribution-widget.md
+++ b/docs/plans/06-baseline-distribution-widget.md
@@ -1,5 +1,7 @@
 # Phase 2 — Build Widget 2: "Baseline changes the shape"
 
+**Update (pivot):** For the improved “baseline vs lift” framing (two average markers), see `docs/plans/08-widget2-pivot-lift-marker.md`.
+
 **Status:** Ready to implement. Widget 1 (`SamplingDistributionBuilder`) is done. This document covers the three files to create and one page edit to wire it in.
 
 ---

--- a/docs/plans/06-baseline-distribution-widget.md
+++ b/docs/plans/06-baseline-distribution-widget.md
@@ -1,0 +1,241 @@
+# Phase 2 — Build Widget 2: "Baseline changes the shape"
+
+**Status:** Ready to implement. Widget 1 (`SamplingDistributionBuilder`) is done. This document covers the three files to create and one page edit to wire it in.
+
+---
+
+## Files to create
+
+### 1. `components/tutorial/chapter-2-constants.ts`
+
+```ts
+export const CH2_BASELINE_MIN  = 0.01;   // 1%
+export const CH2_BASELINE_MAX  = 0.25;   // 25%
+export const CH2_BASELINE_DEFAULT = 0.05; // 5%
+export const CH2_N             = 100;    // sample size (fixed for Ch2)
+export const CH2_SAMPLE_COUNT  = 100;    // draws per batch
+export const CH2_AXIS_MAX      = 0.35;   // fixed x-axis ceiling (35%)
+export const CH2_STAGGER_MS    = 10;     // ms between dot reveals during animation
+export const CH2_DEBOUNCE_MS   = 120;    // ms debounce on slider
+```
+
+Don't import from `sampling-constants.ts` — those are Ch1 values (N=10, P=0.2) and must stay isolated.
+
+---
+
+### 2. `components/tutorial/sampling-rate-distribution.tsx`
+
+The dot plot. Receives pre-computed rates and renders them; owns no sampling logic.
+
+```tsx
+"use client";
+
+import { AxisBottom, AxisLeft } from "@visx/axis";
+import { Group } from "@visx/group";
+import { scaleBand, scaleLinear } from "@visx/scale";
+import { binomialSD } from "@/maths/sampling";
+import { CH2_N, CH2_AXIS_MAX } from "./chapter-2-constants";
+
+type Props = {
+  rates: number[];    // observed sample rates as fractions, e.g. 0.03
+  baseline: number;  // current true baseline as fraction, e.g. 0.05
+};
+```
+
+**Key layout decisions:**
+
+| Constant | Value | Reason |
+|---|---|---|
+| `WIDTH` | 560 | Wider than Widget 1's 420 — 36 bins need room |
+| `HEIGHT` | 320 | Same as Widget 1 |
+| `MARGIN` | `{ top:44, right:20, bottom:50, left:46 }` | Extra bottom for rate axis labels |
+| `PLOT_W` | 494 | 560 − 66 |
+
+**X-axis bins:** integers 0–35, representing 0%–35%. Domain for `scaleBand` is `[0, 1, 2, …, 35]`. Bin a rate `r` with `Math.round(r * 100)`, clamped to `[0, 35]`. Tick labels every 5 bins (`0, 5, 10, 15, 20, 25, 30, 35`) formatted as `"X%"`.
+
+**Y-axis:** `scaleLinear` from 0 to `Math.max(1, maxBucket)`. Same adaptive tick interval logic as Widget 1.
+
+**±2σ band (rendered first, behind dots):**
+```
+const sd = binomialSD(CH2_N, baseline) / CH2_N;  // rate SD (not count SD)
+const loFrac = Math.max(0, baseline - 2 * sd);
+const hiFrac = Math.min(CH2_AXIS_MAX, baseline + 2 * sd);
+const loBin  = Math.round(loFrac * 100);
+const hiBin  = Math.round(hiFrac * 100);
+// rect from left edge of loBin column to right edge of hiBin column
+```
+Color: `fill="currentColor" fillOpacity={0.05}`, no stroke. Label `"~95% of samples"` at top-right of the rect, small text, `fillOpacity={0.3}`.
+
+**True baseline line:**
+```
+const trueBin = Math.round(baseline * 100);
+// vertical dashed line at colX(trueBin), from y=-6 to y=PLOT_H
+// label above: "truth: X%"
+```
+Same style as Widget 1's true-mean marker.
+
+**Dots:**
+Same pattern as `DiscreteSamplingDistribution` — keyed by insertion index, render stacked. Use `animate-dot-drop` CSS class and `transformBox: "fill-box"`. Dot radius `DOT_R_NOMINAL = 4`, same scaling logic if stacks overflow.
+
+**Placeholder slots:** Same dashed placeholder circles above each column's current stack (`PLACEHOLDER_ROWS = 3`).
+
+**Accessible `aria-label`:**
+```
+`Sampling rate distribution of ${rates.length} draws at ${(baseline*100).toFixed(1)}% baseline, ranging from ${loFrac*100}% to ${hiFrac*100}%.`
+```
+
+---
+
+### 3. `components/tutorial/baseline-distribution-widget.tsx`
+
+The wrapper. Owns the slider state, sampling logic, animation, and insight text. Passes `rates[]` and `baseline` down to `SamplingRateDistribution`.
+
+```tsx
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { drawSample, countSample, binomialSD } from "@/maths/sampling";
+import { SamplingRateDistribution } from "./sampling-rate-distribution";
+import {
+  CH2_BASELINE_MIN, CH2_BASELINE_MAX, CH2_BASELINE_DEFAULT,
+  CH2_N, CH2_SAMPLE_COUNT, CH2_STAGGER_MS, CH2_DEBOUNCE_MS,
+} from "./chapter-2-constants";
+```
+
+**State:**
+- `baseline: number` — current slider value (fraction)
+- `rates: number[]` — the visible rates in the chart (grows during animation)
+- `isDrawing: boolean` — lock while animation in progress
+
+**Slider markup:**
+```tsx
+<input
+  type="range"
+  min={CH2_BASELINE_MIN * 100}
+  max={CH2_BASELINE_MAX * 100}
+  step={0.5}
+  value={baseline * 100}
+  onChange={(e) => setBaseline(Number(e.target.value) / 100)}
+  aria-label="Baseline conversion rate"
+  aria-valuetext={`${(baseline * 100).toFixed(1)}%`}
+/>
+```
+Show current value inline: `<span>{(baseline * 100).toFixed(1)}%</span>`.
+
+**Auto-draw on slider settle (debounce):**
+```ts
+const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+useEffect(() => {
+  if (debounceRef.current) clearTimeout(debounceRef.current);
+  debounceRef.current = setTimeout(() => triggerDraw(), CH2_DEBOUNCE_MS);
+  return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+}, [baseline]);
+```
+
+**`triggerDraw` function:**
+```ts
+function triggerDraw() {
+  if (isDrawing) return;
+  setIsDrawing(true);
+  setRates([]);  // clear previous
+
+  const computed = Array.from({ length: CH2_SAMPLE_COUNT }, () => {
+    const marbles = drawSample(CH2_N, baseline);
+    return countSample(marbles) / CH2_N;
+  });
+
+  const timeouts: ReturnType<typeof setTimeout>[] = [];
+  computed.forEach((rate, i) => {
+    const t = setTimeout(() => {
+      setRates((prev) => [...prev, rate]);
+      if (i === computed.length - 1) setIsDrawing(false);
+    }, i * CH2_STAGGER_MS);
+    timeouts.push(t);
+  });
+
+  drawTimeouts.current = timeouts;
+}
+```
+Store timeouts in a ref so reset/remount can cancel them.
+
+**"Draw 100 samples" / "Redraw" button:** calls `triggerDraw()`. Label is `"Draw 100 samples"` before any draw; `"Redraw"` after first draw. Disabled while `isDrawing`.
+
+**Auto-draw on mount:** The `useEffect` on `baseline` fires immediately with `CH2_BASELINE_DEFAULT`, which debounces and triggers the first draw. No extra `useEffect` needed.
+
+**Cleanup on unmount:**
+```ts
+useEffect(() => {
+  return () => {
+    drawTimeouts.current.forEach(clearTimeout);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  };
+}, []);
+```
+
+**Dynamic insight text** (below the chart):
+
+Computed from the current `baseline` value using `binomialSD`:
+```ts
+const sd = binomialSD(CH2_N, baseline) / CH2_N;
+const lo = Math.max(0, (baseline - 2 * sd) * 100);
+const hi = Math.min(35, (baseline + 2 * sd) * 100);
+const spread = hi - lo;
+const multiple = (spread / 2) / (baseline * 100);
+```
+
+| Condition | Text |
+|---|---|
+| `baseline <= 0.03` | `At {X}% baseline, a sample of 100 could show anywhere from {lo}% to {hi}%. That's a spread of {spread.toFixed(1)} points — more than double the truth itself.` |
+| `baseline <= 0.10` | `At {X}% baseline, your sample will land roughly between {lo}% and {hi}%. You can tell broad differences apart, not small ones.` |
+| `baseline > 0.10` | `At {X}% baseline, your sample will land within ~{(spread/2).toFixed(1)} points of the truth. That's tight enough to spot a real change.` |
+
+Numbers use `(baseline * 100).toFixed(1)` for X, `lo.toFixed(0)` / `hi.toFixed(0)` for range.
+
+**`aria-live` region:**
+```tsx
+<div aria-live="polite" className="sr-only">
+  {liveText}
+</div>
+```
+Update `liveText` when draw completes: `"Drew 100 samples at ${X}% baseline, ranging from ${lo}% to ${hi}%."`. Also announce slider changes: `"Baseline changed to ${X}%; redrawing."`.
+
+---
+
+## File to edit
+
+### `app/how-many-visitors-do-you-need/page.tsx`
+
+Replace:
+```tsx
+import { SamplingDistributionBuilder } from "@/components/tutorial/sampling-distribution-builder";
+// ...
+<WidgetFrame>
+  <SamplingDistributionBuilder />
+</WidgetFrame>
+```
+
+With:
+```tsx
+import { BaselineDistributionWidget } from "@/components/tutorial/baseline-distribution-widget";
+// ...
+<WidgetFrame>
+  <BaselineDistributionWidget />
+</WidgetFrame>
+```
+
+No other page changes in this phase — copy restructure is Phase 3.
+
+---
+
+## Verification checklist
+
+- [ ] Slider moves → dots clear immediately → new dots animate in over ~1s
+- [ ] ±2σ band visually widens when baseline is low (2%), narrows relatively when high (20%)
+- [ ] Truth line tracks the slider
+- [ ] Insight text adapts correctly at the three breakpoints (≤3%, 3–10%, >10%)
+- [ ] "Redraw" replaces (not appends) the current distribution
+- [ ] Keyboard: slider is navigable via arrow keys; `aria-valuetext` reads correctly
+- [ ] Screen reader: `aria-live` announces slider moves and completed draws
+- [ ] No layout shift when dots animate in (fixed SVG viewBox + `h-auto`)
+- [ ] Mobile: widget scales down cleanly (SVG is `w-full h-auto`)

--- a/docs/plans/07-page2-copy-arc.md
+++ b/docs/plans/07-page2-copy-arc.md
@@ -1,0 +1,203 @@
+# Phase 3 — Page 2 copy: wire up the story arc
+
+**Status:** Ready after Phase 2 (Widget 2 must exist before the copy references it).
+
+**Goal:** Restructure `app/how-many-visitors-do-you-need/page.tsx` to match the story arc from `05-section-2-widget-plan.md`. The current page has Widget 1 in Widget 2's slot and is missing the opening, bridge paragraph, and post-widget unpacking. Phase 2 moves Widget 2 into the slot; this phase rearranges the full narrative and places Widget 1 properly.
+
+---
+
+## Target page structure (section by section)
+
+All text below is **draft copy** — apply the writing-like-a-human skill before finalising.
+
+---
+
+### 1. Page header (keep as-is)
+
+```tsx
+<p className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
+  {siteConfig.name} · Chapter {chapter.number} of {totalChapters}
+</p>
+<h1 className="mt-2 text-4xl font-semibold tracking-tight sm:text-5xl">
+  {chapter.title}
+</h1>
+```
+
+---
+
+### 2. Opening paragraph (replace current intro)
+
+**Current:** "You know small samples lie. So the next question is obvious: how many visitors do you actually need? There's no universal number. It depends on three things…"
+
+**Replace with:** Something that picks up directly from Ch1's ending ("More data tightens that spread. How much more?") and frames the chapter around building the distribution idea.
+
+Draft:
+> Small samples are noisy. But how noisy, exactly? That's not a philosophical question — it has a precise answer, and the answer changes depending on your product. The key is your baseline conversion rate: how often visitors convert right now, before you change anything. Let's build some intuition.
+
+Keep the `<hr className="my-10 border-foreground/10" />` after.
+
+---
+
+### 3. Widget 1 — "The shape of noise"
+
+**Add new h2 before Widget 1:**
+```tsx
+<h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+  The shape of noise
+</h2>
+```
+
+**Add lead-in paragraph:**
+> Back to the marble jar. True rate: 20%. Each draw of 10 is a sample, and we've seen those samples jump around. But here's what happens when you draw many samples and track where they land: the noise has structure. Keep drawing and watch the right panel.
+
+**Widget 1 block (currently the page has this widget in Widget 2's position — move it here):**
+```tsx
+<div className="mt-6">
+  <WidgetFrame>
+    <SamplingDistributionBuilder />
+  </WidgetFrame>
+</div>
+```
+
+---
+
+### 4. Bridge paragraph
+
+After Widget 1, before "What's a baseline?":
+
+```tsx
+<div className="mt-8 space-y-4 text-foreground/70">
+  <p>
+    What you just drew has a name: a <strong>sampling distribution</strong>. 
+    It's the shape of all the outcomes your experiment could produce, 
+    drawn from the same truth. Tight shape means consistent samples — 
+    you can trust what you measure. Wide shape means your next sample 
+    could be almost anything.
+  </p>
+  <p>
+    That shape isn't fixed. It changes with your baseline conversion rate. 
+    Here's why that matters.
+  </p>
+</div>
+```
+
+---
+
+### 5. Baseline definition (largely keep, minor trim)
+
+**Keep h2:** "What's a baseline?"
+
+**Keep Quote block:**
+> Your **baseline conversion rate** is how many visitors sign up right now, before any change.
+
+**Keep the two definition paragraphs** ("If 100 people hit your signup page…" / "It sounds like background information…"). Trim or keep the third paragraph about version A depending on flow.
+
+---
+
+### 6. Widget 2 — "Baseline changes the shape"
+
+**Replace current h2** ("Two products, two completely different problems") with:
+```tsx
+<h2 className="mt-10 text-2xl font-semibold tracking-tight sm:text-3xl">
+  Baseline changes the shape
+</h2>
+```
+
+**Lead-in paragraphs** (replace current "Imagine two SaaS products…" with something that flows from the shape idea):
+> Slide the baseline below and watch the distribution transform. The shape you built by hand in the widget above now moves with a number.
+
+Or keep the "two products" framing but reference the distribution:
+> Two SaaS products, both hoping for a 20% relative lift. One converts at 2%, the other at 20%. The difference shows up in the shape of their sampling distributions — slide and see.
+
+**Widget 2 block:**
+```tsx
+<div className="mt-6">
+  <WidgetFrame>
+    <BaselineDistributionWidget />
+  </WidgetFrame>
+</div>
+```
+
+---
+
+### 7. Post-widget unpacking (replace current "At low baseline…" paragraphs)
+
+The current two paragraphs are fine but don't reference the two insights the widget reveals. Replace with:
+
+```tsx
+<div className="mt-8 space-y-4 text-foreground/70">
+  <p>
+    Notice two things. First, the absolute width of the distribution grows 
+    with baseline — a 20% jar produces more spread in percentage points than 
+    a 2% jar. Second, the <em>relative</em> width shrinks. At 2%, a single 
+    sample could show anywhere from 0% to 5% — that's 2.5× the true rate. 
+    At 20%, the same sample lands within a few points of the truth.
+  </p>
+  <p>
+    The relative width is what matters. When you're trying to tell "version A 
+    vs. version B differs by 0.4 percentage points" from noise, a distribution 
+    that spans 3 points around a 2% truth is essentially useless. A distribution 
+    that spans 4 points around a 20% truth is workable.
+  </p>
+</div>
+```
+
+---
+
+### 8. Signal-to-noise section (keep h2 and paragraphs, minor edits)
+
+**Keep h2:** "The signal-to-noise problem"
+
+**Keep the two paragraphs** (rare-event framing, "ten times the signal").
+
+---
+
+### 9. Quote (keep)
+
+> The lower your baseline, the more data you need to hear the signal above the noise.
+
+---
+
+### 10. Implication paragraphs (keep, minor edits)
+
+The "landing page at 2% baseline typically needs 10 to 20 times more visitors…" paragraph — keep as-is.
+
+The "This is why there's no universal answer…" paragraph — keep.
+
+The "One thing worth naming: we've been using 100 visitors…" note — keep.
+
+---
+
+### 11. SectionFooter (keep as-is)
+
+```tsx
+<SectionFooter
+  summary={[...]}
+  teaserText="..."
+  nextLabel="Next: Confidence →"
+  nextHref="/how-sure-do-you-need-to-be"
+/>
+```
+
+---
+
+## Import changes
+
+After Phase 3, `page.tsx` imports:
+```tsx
+import { SamplingDistributionBuilder } from "@/components/tutorial/sampling-distribution-builder";   // Widget 1
+import { BaselineDistributionWidget } from "@/components/tutorial/baseline-distribution-widget";     // Widget 2
+```
+
+Widget 1 (`SamplingDistributionBuilder`) is **re-added** in its correct earlier position (section 3 above). Phase 2 only replaced it with Widget 2 — Phase 3 adds it back earlier on the page.
+
+---
+
+## What to apply the writing-like-a-human skill to
+
+Before finalising, run the skill on:
+- The new opening paragraph (section 2)
+- The bridge paragraph (section 4)
+- The post-widget unpacking (section 7)
+
+The existing baseline definition and signal-to-noise copy already passed a prior review — only touch them if the surrounding structure requires adjustment.

--- a/docs/plans/08-widget2-pivot-lift-marker.md
+++ b/docs/plans/08-widget2-pivot-lift-marker.md
@@ -1,0 +1,123 @@
+# Pivot plan — Widget 2: show baseline vs a realistic lift
+
+**Problem:** the current Widget 2 (dots + “~95% of samples” band + “truth” line) makes it hard to *feel* why 2% baseline is worse (less signal) than 20%. The reader sees “a shape”, but not whether a real lift would stand out from the noise.
+
+**Pivot:** keep the dot distribution, but add a second vertical marker for a hypothetical variant with a fixed relative lift (start at +10%). The chart becomes a simple question: **are these two averages meaningfully separated compared to the spread of the dots?**
+
+This is still one lever (baseline). Lift is fixed, not user-controlled.
+
+---
+
+## Model
+
+- Control (baseline): $p$
+- Variant (with lift): $p_\text{lift} = p \cdot (1 + \text{lift})$
+- Default lift: `CH2_LIFT = 0.10` (10% relative)
+
+At baseline = 2%, this is 2.0% → 2.2% (gap 0.2pp). At baseline = 20%, it’s 20% → 22% (gap 2pp).
+
+---
+
+## UI changes
+
+### Chart: keep the dots, add two markers
+
+In `SamplingRateDistribution`:
+
+- Keep the dot plot and x-axis exactly as-is (0%–35%, 1pp columns).
+- Keep the shaded band, but change the label from `~95% of samples` to something more literal like `typical range` (optionally add `(±2σ)` in smaller text if it fits).
+- Rename the existing marker label from `truth` to `average` (or `baseline avg`).
+- Add a second marker for the lifted average:
+  - Label: `+10% lift: Y%` (computed from the current baseline).
+  - Style: different from baseline marker (both color and dash pattern).
+
+**Key detail:** keep dots snapped to 1pp bins, but draw both vertical marker lines at a continuous x-position so small gaps (2.0 → 2.2) don’t collapse to the same column.
+
+A simple way to do this without changing the dot layout:
+
+- Continue using the existing `scaleBand` for dot columns.
+- Add a second x-scale for values in percent:
+  - `xValueScale = scaleLinear({ domain: [-0.5, MAX_BIN + 0.5], range: [0, PLOT_W] })`
+  - Baseline line at `xValueScale(baseline * 100)`
+  - Lift line at `xValueScale(baseline * (1 + lift) * 100)`
+
+Clamps:
+- Clamp the lifted rate to the axis ceiling (`CH2_AXIS_MAX`) so the line never disappears off the chart.
+
+### Styling (no new theme tokens)
+
+Use existing colors already present in the widget:
+
+- Baseline marker: `currentColor` with medium opacity, dashed.
+- Lift marker: use the same green as the dots (`#16a34a`) but with a different dash pattern (or solid line) so it reads as a separate thing.
+
+Keep the dots green (they represent observed samples drawn at the baseline). The lift marker is a “where the variant average would land” reference line, not a second distribution.
+
+---
+
+## Copy changes
+
+### Insight text below the chart
+
+Update the dynamic text in `BaselineDistributionWidget` to explicitly connect “low baseline = low signal” to the lift marker.
+
+Proposed structure:
+
+- Always include the lift in percentage points: `delta = baseline * lift * 100`.
+- Always include the typical noise scale: `noise ≈ 2σ` in points (already computed via `binomialSD`).
+
+Examples (exact wording can be tuned, but keep it plain):
+
+- At low baseline (≤ 3%):
+  - “A +10% lift is only ~0.2 points at 2.0%. That sits inside the usual wobble of a 100-person sample.”
+- Mid (3–10%):
+  - “The lift line moves, but most samples still bounce around a lot. You can spot big shifts, not small ones.”
+- High (> 10%):
+  - “A +10% lift is a few points here, so the two averages separate on the axis. But single samples still vary.”
+
+### Accessibility text
+
+- `aria-label` on the SVG should mention both markers:
+  - “Sampling rate distribution of 100 draws at X% baseline, with a +10% lift marker at Y%, …”
+- `aria-live` should announce the marker too:
+  - On slider change: “Baseline changed to X%. Showing +10% lift marker at Y%. Redrawing.”
+  - On draw complete: “Drew 100 samples at X%. Lift marker at Y%. Range A% to B%.”
+
+---
+
+## Files to edit
+
+- `components/tutorial/chapter-2-constants.ts`
+  - Ensure `CH2_LIFT` exists (start at `0.10`).
+
+- `components/tutorial/sampling-rate-distribution.tsx`
+  - Add a `lift` input (prop or import constant) and render the second vertical marker.
+  - Draw markers using a continuous x-position (don’t round to bins).
+  - Update band label (“typical range”), marker labels (“average”, “+lift”), and SVG `aria-label`.
+
+- `components/tutorial/baseline-distribution-widget.tsx`
+  - Pass lift value through (or import it and keep the chart signature stable).
+  - Update insight text to reference the lift gap in points.
+  - Update `aria-live` messages.
+
+---
+
+## Tuning step (allowed scope)
+
+If +10% doesn’t read well on-screen:
+
+- Keep the same UI, only change `CH2_LIFT`.
+- Try `0.15` or `0.20` and re-check two anchor baselines:
+  - 2% (should still be “basically indistinguishable”)
+  - 20% (lines should clearly separate)
+
+---
+
+## Verification checklist
+
+- [ ] At baseline ≈ 2%, the lift marker is extremely close to the baseline marker (not snapped onto the same pixel).
+- [ ] At baseline ≈ 20%, the lift marker visibly separates from the baseline marker.
+- [ ] Dots still render in 1pp columns and animate as before.
+- [ ] Slider drag clears dots and redraws with debounce; markers update immediately.
+- [ ] Band label reads as “typical range” (not a stats lesson).
+- [ ] Screen reader announcements mention baseline and the lift marker.

--- a/docs/plans/08-widget2-pivot-lift-marker.md
+++ b/docs/plans/08-widget2-pivot-lift-marker.md
@@ -24,7 +24,7 @@ At baseline = 2%, this is 2.0% → 2.2% (gap 0.2pp). At baseline = 20%, it’s 2
 
 In `SamplingRateDistribution`:
 
-- Keep the dot plot and x-axis exactly as-is (0%–35%, 1pp columns).
+- Keep the dot plot and x-axis exactly as-is (0%–35%, 1pp columns). *(v2 edit: implementation intentionally expanded the axis to 0%–60%, 61 columns, for better visual contrast between low and high baselines — e.g. the 50% bell fits fully on screen without crowding.)*
 - Keep the shaded band, but change the label from `~95% of samples` to something more literal like `typical range` (optionally add `(±2σ)` in smaller text if it fits).
 - Rename the existing marker label from `truth` to `average` (or `baseline avg`).
 - Add a second marker for the lifted average:

--- a/docs/plans/09-page3-plan.md
+++ b/docs/plans/09-page3-plan.md
@@ -1,0 +1,124 @@
+# Chapter 3 plan — two bells and the overlap problem
+
+**Route:** `/how-sure-do-you-need-to-be` (file does not yet exist)
+
+**Status:** Draft. Chapter 2 now ends by teasing "version B has its own bell — next chapter we put them both on the chart." This plan picks up from there.
+
+**Chapter title candidates (pick one before implementing):**
+- "How sure do you need to be?" (matches the current `nextLabel` and original `docs/chapters.md`)
+- "When can you tell them apart?" (closer to the actual visual payoff of the chapter)
+
+Default to the first for consistency with existing nav; revisit if the overlap framing becomes the stronger hook.
+
+---
+
+## The arc
+
+Chapter 2 leaves the reader with one bell (the control) and a dashed lift line showing where version B would land. The reader can see that at low baselines the line hides inside the spread, and at higher baselines it separates.
+
+Chapter 3 does three things, in order:
+
+1. **Promote the lift line to a full bell.** Version B has its own sampling distribution, centered on `baseline * (1 + lift)`, with the same width (same N, same `p(1-p)/n` to first order). Two bells, one chart.
+2. **Make the overlap visible.** At low baseline or low N, the two bells heavily overlap — a single sample from B could land anywhere in A's bell, and vice versa. At higher baseline or higher N, they separate.
+3. **Name the decision.** Deciding "B won" really means drawing a line somewhere between the two bells. Where you draw the line is your **confidence level**. A stricter line means fewer false positives but needs more separation (more data) to clear. This is the bridge into chapter 4's sample-size calculator framing.
+
+Keep the running case study (signup button, baseline 10%, 10% relative lift) as the default state so numbers stay consistent with page 1 and page 2.
+
+---
+
+## Widgets
+
+### Widget 1 — Two bells (primary)
+
+Working name: `TwoBellsWidget` (or reuse `BaselineDistributionWidget` with a prop).
+
+**What it shows:**
+- Same x-axis as the ch2 widget (observed conversion rate per sample).
+- Control bell centered at `baseline`, variant bell centered at `baseline * (1 + lift)`.
+- Both bells shaded; overlap region rendered in a third tone so it pops.
+- Vertical markers at both means, keeping the dashed "B" and solid "A" styling from ch2 for continuity.
+
+**Controls (one lever at a time, building from ch2):**
+- Baseline slider (same steps as ch2: 1, 2, 5, 10, 20, 30, 40, 50%).
+- Optional second lever: N slider (e.g. 100, 500, 2000, 10000). Start N fixed at 100 for continuity with ch2, unlock N later in the chapter if it reads better as a separate beat.
+
+**Key observation to prompt for in copy:**
+- At 2% baseline and N=100, the two bells sit almost on top of each other.
+- At 20% baseline, the means pull apart but the bells still overlap noticeably.
+- At 20% baseline and N=10000, the bells shrink to near-spikes and fully separate.
+
+Lift stays fixed at `CH2_LIFT = 0.10` to keep the "same relative improvement, different pictures" thread from ch2.
+
+### Widget 2 — Where do you draw the line? (optional, second half of chapter)
+
+Either a second widget or an extension of Widget 1:
+
+- Add a vertical "decision threshold" line between the two bells.
+- Shade the area of A's bell to the right of the threshold (false positives) and the area of B's bell to the left of the threshold (false negatives / missed wins).
+- Slider for confidence level (80 / 90 / 95 / 99%) moves the threshold.
+
+Only introduce this once the two-bell picture is locked in. If it makes the chapter too dense, defer to chapter 4 and keep ch3 focused on overlap.
+
+---
+
+## Page structure (target)
+
+1. Eyebrow + h1 (chapter title). Pattern matches ch1/ch2.
+2. Opening paragraph: pick up exactly where ch2 ended. One bell in, one to go.
+3. h2: "Version B has its own bell"
+   - Lead-in paragraph explaining that B is drawn from a jar whose true rate is `baseline * (1 + lift)`, so its sampling distribution has the same shape, just shifted right.
+   - `TwoBellsWidget` in default state (baseline 10%, N=100).
+4. Post-widget: walk through what the overlap means. Use concrete numbers: at 10% baseline with N=100, A's 95% range is roughly 4–16%; B's is roughly 5–17%. A single sample can't reliably tell them apart.
+5. h2: "Slide the baseline and watch the overlap move"
+   - Prompt the reader to try 2% and 20%. Describe what they should see in prose afterwards.
+6. h2: "Where do you draw the line?" (only if Widget 2 ships in ch3)
+   - Introduce the decision-threshold idea; widget 2 or extended widget 1.
+   - Paragraph on the tradeoff: stricter threshold = fewer false positives, needs more separation = more data.
+7. Quote: something like "A winner is a gap big enough that you would not see it by chance."
+8. h2: "What confidence actually costs"
+   - Short: higher confidence shifts the threshold further out, which means more data to clear it. Connect to ch4.
+9. SectionFooter teasing chapter 4 (minimum detectable lift and the full calculator).
+
+All prose should be drafted in the `writing-like-a-human` voice before shipping. Keep sentences varied, no em dashes, no "crucial/pivotal," no triplet overuse.
+
+---
+
+## Files this chapter will touch
+
+- `app/how-sure-do-you-need-to-be/page.tsx` — new.
+- `components/tutorial/chapters.ts` — add chapter 3 entry (`title`, `shortTitle`, `browserTitle`, `description`).
+- `components/tutorial/two-bells-widget.tsx` — new, or extend `baseline-distribution-widget.tsx` to accept a `variant` mode.
+- `components/tutorial/chapter-3-constants.ts` — new, or reuse CH2_N, CH2_LIFT, CH2_BASELINE_STEPS so the two chapters stay in sync.
+- `components/tutorial/tutorial-nav.tsx` — no change if it reads from `chapters.ts`.
+- `app/how-many-visitors-do-you-need/page.tsx` — `nextHref` already points at the new route; no change.
+
+---
+
+## Implementation notes
+
+### Bell shape reuse
+
+The theoretical shape logic already lives in `buildTheoreticalBuckets` in `baseline-distribution-widget.tsx`. For the two-bell widget, call it twice with different `p` values and render both bucket sets. Consider extracting the function into `maths/sampling.ts` so both chapters can import it cleanly.
+
+### Overlap rendering
+
+Simplest: render the B bell's dots at the same x-positions but with a distinct fill (e.g. amber vs. the existing green), stacked independently. Overlap becomes visible as two colored columns co-existing at the same x-bins.
+
+Alternative: render both as smoothed area curves (switch from dot-stacks to filled paths) and blend the colors in the overlap region. Reads more like a textbook stats chart but loses the "each dot is a possible outcome" interpretation the reader built in ch2. Start with the dot-stack version for continuity; switch only if it reads badly side-by-side.
+
+### Dot count
+
+With 400 dots per distribution, two distributions means 800 dots on screen. Test at 2% baseline where the bells stack almost identically — that is the visual stress test. If it overcrowds, drop per-distribution dot count to 250 and keep the rest of the scaling identical.
+
+### Accessibility
+
+Two bells means the ch2 aria-label pattern ("Theoretical sampling distribution at X% baseline …") needs to mention both means. Draft:
+`"Two sampling distributions: control at X% (solid), variant at Y% (dashed), N=Z. Overlap is {heavy|moderate|light}."`
+
+---
+
+## Open questions
+
+- Does chapter 3 own the N slider, or does that belong in chapter 4 with the full calculator? Current lean: **N slider belongs to chapter 4** so chapter 3 has one clean lever (baseline) and one clean idea (overlap → confidence). Revisit if the two-bell picture alone is too static without N.
+- Title: "How sure do you need to be?" (confidence-forward) vs. "When can you tell them apart?" (overlap-forward). Pick during drafting.
+- Should the chapter end with the confidence/threshold widget, or defer it to chapter 4 entirely? If it defers, chapter 3 is a short, tight chapter on overlap alone. That might read better than one long chapter on overlap + confidence.


### PR DESCRIPTION
- Add plan for page 2 widget #2
- Add widget (slight pivot from written plan), since first plan was visually not clear enough:
 now, instead of random samples, we show a theoretical distribuiton here (still discrete to not introduce too many concepts with a continuous curve). this reduces variability and makes the chart less crowded, it allows the user to focus on the vertical lift line being closer or further from the mean. so they can see that on a low baseline, the signal is losing itself. the higher the baseline, the easier it is to see a difference (at the same constant 10% lift).
 Almost no copy updates yet on that page (comes later), and the widgets are just added there one after the other.
 
 