### PR TITLE
Fix marble widget on mobile & marble illustration

### DIFF
--- a/app/why-small-samples-lie/page.tsx
+++ b/app/why-small-samples-lie/page.tsx
@@ -62,13 +62,15 @@ export default function Section1Page() {
       <p className="mt-8 text-foreground/70">
         Imagine every potential visitor is a marble in a jar. Green means they
         signed up; grey means they didn&apos;t. The jar below has a true
-        conversion rate of {aPercent}%: 1 in every {Math.round(1 / CASE_STUDY_A_RATE)}, on average. Draw a sample of 10
-        and count the green ones. What do you notice about the average as you
-        draw more and more samples?
+        conversion rate of {aPercent}%: 1 in every {Math.round(1 / CASE_STUDY_A_RATE)}, on average.
       </p>
 
       <div className="mt-6 flex flex-col items-center gap-4">
         <JarIllustration />
+        <p className="text-foreground/70">
+          Draw a sample of 10 and count the green ones. What do you notice about the average as you
+          draw more and more samples?
+        </p>
         <WidgetFrame>
           <MarbleSamplingWidget />
         </WidgetFrame>

--- a/components/tutorial/illustrations/jar-illustration.tsx
+++ b/components/tutorial/illustrations/jar-illustration.tsx
@@ -5,17 +5,16 @@
 
 import { P } from "../constants/sampling-constants";
 
-export const WJAR_W = 260;
+const WJAR_W = 260;
 const WJAR_H = 250;
 const WJAR_RIM = 25;
 const WMR = 9;
 const WMGAP = 4;
 const WMSTEP = WMR * 2 + WMGAP;
 const WCOLS = 10;
-const WROWS = 4;
+const WROWS = 6;
 const WSTART_X = (WJAR_W - (WCOLS * WMSTEP - WMGAP)) / 2 + 10;
-const WROW_YS = [122, 158, 194, 230];
-//const WROW_YS = [42, 78, 114, 150];
+const WROW_YS = [50, 86, 122, 158, 194, 230];
 
 // Oval circles cols 0–9 of each row
 const WOVAL_COLS = 10;
@@ -45,7 +44,7 @@ const WIDE_MARBLES = generateWideMarbles();
 
 export function JarIllustration() {
   return (
-    <div className="w-full rounded-xl border border-foreground/10 px-3 py-4">
+    <div className="w-full rounded-xl px-3 py-4">
       <div className="mx-auto w-4/5">
         <div className="relative w-full" style={{ height: "clamp(220px, 45vw, 320px)" }}>
           <svg
@@ -121,7 +120,7 @@ export function JarIllustration() {
             </g>
 
             {/* 3 sample ovals on rows 0, 1, 2 */}
-            {[0, 1, 2].map((ri) => {
+            {[0, 1, 2, 3, 4, 5].map((ri) => {
               const cy = WROW_YS[ri];
               return (
                 <g key={ri}>

--- a/components/tutorial/illustrations/jar-illustration.tsx
+++ b/components/tutorial/illustrations/jar-illustration.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-// Wide horizontal jar with 4 rows of marbles and 3 sample ovals circled inside.
+// Jar with 6 rows of marbles and all rows circled as samples inside.
 
 import { P } from "../constants/sampling-constants";
 
@@ -119,7 +119,7 @@ export function JarIllustration() {
               })}
             </g>
 
-            {/* 3 sample ovals on rows 0, 1, 2 */}
+            {/* 6 sample ovals on rows 0 through 5 */}
             {[0, 1, 2, 3, 4, 5].map((ri) => {
               const cy = WROW_YS[ri];
               return (

--- a/components/tutorial/illustrations/jar-illustration.tsx
+++ b/components/tutorial/illustrations/jar-illustration.tsx
@@ -5,16 +5,17 @@
 
 import { P } from "../constants/sampling-constants";
 
-export const WJAR_W = 420;
-const WJAR_H = 168;
-const WJAR_RIM = 18;
+export const WJAR_W = 260;
+const WJAR_H = 250;
+const WJAR_RIM = 25;
 const WMR = 9;
 const WMGAP = 4;
 const WMSTEP = WMR * 2 + WMGAP;
-const WCOLS = 12;
+const WCOLS = 10;
 const WROWS = 4;
-const WSTART_X = (WJAR_W - (WCOLS * WMSTEP - WMGAP)) / 2;
-const WROW_YS = [42, 78, 114, 150];
+const WSTART_X = (WJAR_W - (WCOLS * WMSTEP - WMGAP)) / 2 + 10;
+const WROW_YS = [122, 158, 194, 230];
+//const WROW_YS = [42, 78, 114, 150];
 
 // Oval circles cols 0–9 of each row
 const WOVAL_COLS = 10;
@@ -44,98 +45,113 @@ const WIDE_MARBLES = generateWideMarbles();
 
 export function JarIllustration() {
   return (
-    <svg
-      width={WJAR_W}
-      height={WJAR_H + 8}
-      viewBox={`0 0 ${WJAR_W} ${WJAR_H + 8}`}
-      style={{ display: "block" }}
-      aria-hidden="true"
-    >
-      <defs>
-        <clipPath id="wjar-clip">
-          <rect
-            x={0}
-            y={WJAR_RIM}
-            width={WJAR_W}
-            height={WJAR_H - WJAR_RIM}
-            rx={10}
-          />
-        </clipPath>
-      </defs>
+    <div className="w-full rounded-xl border border-foreground/10 px-3 py-4">
+      <div className="mx-auto w-4/5">
+        <div className="relative w-full" style={{ height: "clamp(220px, 45vw, 320px)" }}>
+          <svg
+            viewBox={`0 0 ${WJAR_W} ${WJAR_H + 8}`}
+            className="absolute inset-0 h-full w-full"
+            preserveAspectRatio="xMidYMid meet"
+            aria-hidden="true"
+          >
+            <defs>
+              <clipPath id="wjar-clip">
+                <rect
+                  x={0}
+                  y={WJAR_RIM}
+                  width={WJAR_W}
+                  height={WJAR_H - WJAR_RIM}
+                  rx={10}
+                />
+              </clipPath>
+            </defs>
 
-      {/* Jar body */}
-      <rect
-        x={0}
-        y={WJAR_RIM}
-        width={WJAR_W}
-        height={WJAR_H - WJAR_RIM}
-        rx={10}
-        fill="#f0f0ee"
-        stroke="rgba(23,23,23,0.14)"
-        strokeWidth="1.5"
-      />
-      {/* Rim */}
-      <rect
-        x={0}
-        y={0}
-        width={WJAR_W}
-        height={WJAR_RIM}
-        rx={4}
-        fill="#e8e8e6"
-        stroke="rgba(23,23,23,0.14)"
-        strokeWidth="1.2"
-      />
-      <text
-        x={WJAR_W / 2}
-        y={WJAR_RIM - 4}
-        textAnchor="middle"
-        fontSize="8"
-        fill="rgba(23,23,23,0.35)"
-        fontWeight="600"
-        letterSpacing="0.12em"
-      >
-                JAR
+            {/* Jar body */}
+            <rect
+              x={0}
+              y={WJAR_RIM}
+              width={WJAR_W}
+              height={WJAR_H - WJAR_RIM}
+              rx={10}
+              fill="#f0f0ee"
+              stroke="rgba(23,23,23,0.14)"
+              strokeWidth="1.5"
+            />
+            {/* Rim */}
+            <rect
+              x={0}
+              y={0}
+              width={WJAR_W}
+              height={WJAR_RIM}
+              rx={4}
+              fill="#e8e8e6"
+              stroke="rgba(23,23,23,0.14)"
+              strokeWidth="1.2"
+            />
+            <text
+              x={WJAR_W / 2}
+              y={WJAR_RIM - 10}
+              textAnchor="middle"
+              fontSize="10"
+              fill="rgba(0, 0, 0, 1)"
+              fontWeight="600"
+              letterSpacing="0.12em"
+            >
+              Marble Jar
             </text>
 
             {/* Marbles */}
             <g clipPath="url(#wjar-clip)">
-                {WIDE_MARBLES.map((m, i) => {
-                    const cx = WSTART_X + m.col * WMSTEP + WMR;
-                    const cy = WROW_YS[m.row];
-                    return (
-                        <g key={i}>
-                            <circle cx={cx + 1} cy={cy + 1.5} r={WMR} fill="rgba(0,0,0,0.07)" />
-                            <circle cx={cx} cy={cy} r={WMR} fill={m.green ? "#16a34a" : "#d4d4d4"} />
-                            <circle
-                                cx={cx - 2.5} cy={cy - 2.5} r={WMR * 0.32}
-                                fill={m.green ? "rgba(255,255,255,0.42)" : "rgba(255,255,255,0.7)"}
-                            />
-                        </g>
-                    );
-                })}
+              {WIDE_MARBLES.map((m, i) => {
+                const cx = WSTART_X + m.col * WMSTEP + WMR;
+                const cy = WROW_YS[m.row];
+                return (
+                  <g key={i}>
+                    <circle cx={cx + 1} cy={cy + 1.5} r={WMR} fill="rgba(0,0,0,0.07)" />
+                    <circle cx={cx} cy={cy} r={WMR} fill={m.green ? "#16a34a" : "#d4d4d4"} />
+                    <circle
+                      cx={cx - 2.5}
+                      cy={cy - 2.5}
+                      r={WMR * 0.32}
+                      fill={m.green ? "rgba(255,255,255,0.42)" : "rgba(255,255,255,0.7)"}
+                    />
+                  </g>
+                );
+              })}
             </g>
 
             {/* 3 sample ovals on rows 0, 1, 2 */}
             {[0, 1, 2].map((ri) => {
-                const cy = WROW_YS[ri];
-                return (
-                    <g key={ri}>
-                        <rect
-                            x={WSTART_X - 8} y={cy - WOVAL_RY}
-                            width={WOVAL_W} height={WOVAL_RY * 2}
-                            rx={10}
-                            fill="rgba(239,68,68,0.05)"
-                            stroke="#747474" strokeWidth="1.5" strokeDasharray="5 3"
-                        />
-                        <text
-                            x={WSTART_X - 12} y={cy + 4} textAnchor="end"
-                            fontSize="10" fill="#747474" fontWeight="600"
-                        >
-                            #{ri + 1}
-                        </text>
-                    </g>
-                );
+              const cy = WROW_YS[ri];
+              return (
+                <g key={ri}>
+                  <rect
+                    x={WSTART_X - 8}
+                    y={cy - WOVAL_RY}
+                    width={WOVAL_W}
+                    height={WOVAL_RY * 2}
+                    rx={10}
+                    fill="rgba(239,68,68,0.05)"
+                    stroke="#747474"
+                    strokeWidth="1.5"
+                    strokeDasharray="5 3"
+                  />
+                  <text
+                    x={WSTART_X - 12}
+                    y={cy + 4}
+                    textAnchor="end"
+                    fontSize="10"
+                    fill="#747474"
+                    fontWeight="600"
+                  >
+                    #{ri + 1}
+                  </text>
+                </g>
+              );
             })}
-        </svg>
-    );
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/components/tutorial/widgets/discrete-sampling-distribution.tsx
+++ b/components/tutorial/widgets/discrete-sampling-distribution.tsx
@@ -4,12 +4,11 @@ import { AxisBottom, AxisLeft } from "@visx/axis";
 import { Group } from "@visx/group";
 import { scaleBand, scaleLinear } from "@visx/scale";
 import { N, P } from "../constants/sampling-constants";
-import { WJAR_W } from "../illustrations/jar-illustration";
 import { binomialMean } from "@/maths/sampling";
 
 type Props = { counts: number[] };
 
-const WIDTH = WJAR_W;
+const WIDTH = 420;
 const HEIGHT = 320;
 const MARGIN = { top: 40, right: 18, bottom: 46, left: 42 };
 const PLOT_W = WIDTH - MARGIN.left - MARGIN.right;

--- a/components/tutorial/widgets/discrete-sampling-distribution.tsx
+++ b/components/tutorial/widgets/discrete-sampling-distribution.tsx
@@ -8,7 +8,7 @@ import { binomialMean } from "@/maths/sampling";
 
 type Props = { counts: number[] };
 
-const WIDTH = 420;
+const WIDTH = 670;
 const HEIGHT = 320;
 const MARGIN = { top: 40, right: 18, bottom: 46, left: 42 };
 const PLOT_W = WIDTH - MARGIN.left - MARGIN.right;
@@ -56,7 +56,7 @@ export function DiscreteSamplingDistribution({ counts }: Props) {
   );
 
   return (
-    <div className="flex w-full max-w-[420px] flex-col items-center gap-2">
+    <div className={`flex w-full max-w-[${WIDTH}px] flex-col items-center gap-2`}>
       <svg
         viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
         preserveAspectRatio="xMidYMid meet"

--- a/components/tutorial/widgets/marble-row.tsx
+++ b/components/tutorial/widgets/marble-row.tsx
@@ -18,10 +18,10 @@ export function MarbleRow({
   return (
     <div className="flex justify-center py-1">
       <div
-        className={`grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[max-content_auto_max-content] ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
+        className={`grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[minmax(4ch,auto)_auto_minmax(4ch,auto)] ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
       >
         {/* Label */}
-        <span className="whitespace-nowrap text-right text-[10px] text-foreground/40 tabular-nums sm:text-[11px]">
+        <span className="whitespace-nowrap text-right text-[10px] text-foreground/40 tabular-nums font-mono sm:text-[11px]">
           #{sampleNumber}
         </span>
 
@@ -50,7 +50,7 @@ export function MarbleRow({
 
         {/* Hit count */}
         <span
-          className={`text-left text-[12px] font-semibold tabular-nums sm:text-[13px] ${count > 0 ? "text-green-600" : "text-foreground/35"
+          className={`text-left text-[12px] font-semibold tabular-nums font-mono sm:text-[13px] ${count > 0 ? "text-green-600" : "text-foreground/35"
             }`}
         >
           {count}/{marbles.length}

--- a/components/tutorial/widgets/marble-row.tsx
+++ b/components/tutorial/widgets/marble-row.tsx
@@ -17,20 +17,20 @@ export function MarbleRow({
   const count = countSample(marbles);
   return (
     <div
-      className={`flex items-center gap-[10px] py-1 ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
+      className={`flex items-center gap-[8px] py-1 sm:gap-[10px] ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
     >
       {/* Label */}
-      <span className="w-[68px] shrink-0 whitespace-nowrap text-right text-[11px] text-foreground/40 tabular-nums">
+      <span className="w-[56px] shrink-0 whitespace-nowrap text-right text-[10px] text-foreground/40 tabular-nums sm:w-[68px] sm:text-[11px]">
         #{sampleNumber}
       </span>
 
       {/* Marble dots */}
-      <div className="flex shrink-0 gap-[3px]">
+      <div className="flex shrink-0 gap-[2px] sm:gap-[3px]">
         {marbles.map((isHit, i) => (
           <div
             key={i}
             aria-hidden="true"
-            className={`relative flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[9px] font-bold ${isNew ? "animate-pop-in" : ""
+            className={`relative flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-[8px] font-bold sm:h-[22px] sm:w-[22px] sm:text-[9px] ${isNew ? "animate-pop-in" : ""
               } ${isHit
                 ? "bg-green-600 text-white"
                 : "border border-foreground/[0.18] text-foreground/25"
@@ -39,7 +39,7 @@ export function MarbleRow({
             {isHit && (
               <span
                 aria-hidden="true"
-                className="pointer-events-none absolute left-[4px] top-[3px] h-[4px] w-[6px] -rotate-[30deg] rounded-full bg-white/40"
+                className="pointer-events-none absolute left-[3px] top-[2px] h-[3px] w-[5px] -rotate-[30deg] rounded-full bg-white/40 sm:left-[4px] sm:top-[3px] sm:h-[4px] sm:w-[6px]"
               />
             )}
             {isHit ? "✓" : "✗"}
@@ -49,7 +49,7 @@ export function MarbleRow({
 
       {/* Hit count */}
       <span
-        className={`w-9 shrink-0 text-[13px] font-semibold tabular-nums ${count > 0 ? "text-green-600" : "text-foreground/35"
+        className={`w-8 shrink-0 text-[12px] font-semibold tabular-nums sm:w-9 sm:text-[13px] ${count > 0 ? "text-green-600" : "text-foreground/35"
           }`}
       >
         {count}/{marbles.length}

--- a/components/tutorial/widgets/marble-row.tsx
+++ b/components/tutorial/widgets/marble-row.tsx
@@ -16,44 +16,46 @@ export function MarbleRow({
 }: Props) {
   const count = countSample(marbles);
   return (
-    <div
-      className={`flex items-center gap-[8px] py-1 sm:gap-[10px] ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
-    >
-      {/* Label */}
-      <span className="w-[56px] shrink-0 whitespace-nowrap text-right text-[10px] text-foreground/40 tabular-nums sm:w-[68px] sm:text-[11px]">
-        #{sampleNumber}
-      </span>
-
-      {/* Marble dots */}
-      <div className="flex shrink-0 gap-[2px] sm:gap-[3px]">
-        {marbles.map((isHit, i) => (
-          <div
-            key={i}
-            aria-hidden="true"
-            className={`relative flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-[8px] font-bold sm:h-[22px] sm:w-[22px] sm:text-[9px] ${isNew ? "animate-pop-in" : ""
-              } ${isHit
-                ? "bg-green-600 text-white"
-                : "border border-foreground/[0.18] text-foreground/25"
-              }`}
-          >
-            {isHit && (
-              <span
-                aria-hidden="true"
-                className="pointer-events-none absolute left-[3px] top-[2px] h-[3px] w-[5px] -rotate-[30deg] rounded-full bg-white/40 sm:left-[4px] sm:top-[3px] sm:h-[4px] sm:w-[6px]"
-              />
-            )}
-            {isHit ? "✓" : "✗"}
-          </div>
-        ))}
-      </div>
-
-      {/* Hit count */}
-      <span
-        className={`w-8 shrink-0 text-[12px] font-semibold tabular-nums sm:w-9 sm:text-[13px] ${count > 0 ? "text-green-600" : "text-foreground/35"
-          }`}
+    <div className="flex justify-center py-1">
+      <div
+        className={`grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[max-content_auto_max-content] ${isFading ? "animate-slide-out-down" : ""} ${isNew ? "animate-slide-down" : ""}`}
       >
-        {count}/{marbles.length}
-      </span>
+        {/* Label */}
+        <span className="whitespace-nowrap text-right text-[10px] text-foreground/40 tabular-nums sm:text-[11px]">
+          #{sampleNumber}
+        </span>
+
+        {/* Marble dots */}
+        <div className="flex justify-center gap-[2px] sm:gap-[3px]">
+          {marbles.map((isHit, i) => (
+            <div
+              key={i}
+              aria-hidden="true"
+              className={`relative flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-[8px] font-bold sm:h-[22px] sm:w-[22px] sm:text-[9px] ${isNew ? "animate-pop-in" : ""
+                } ${isHit
+                  ? "bg-green-600 text-white"
+                  : "border border-foreground/[0.18] text-foreground/25"
+                }`}
+            >
+              {isHit && (
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-[3px] top-[2px] h-[3px] w-[5px] -rotate-[30deg] rounded-full bg-white/40 sm:left-[4px] sm:top-[3px] sm:h-[4px] sm:w-[6px]"
+                />
+              )}
+              {isHit ? "✓" : "✗"}
+            </div>
+          ))}
+        </div>
+
+        {/* Hit count */}
+        <span
+          className={`text-left text-[12px] font-semibold tabular-nums sm:text-[13px] ${count > 0 ? "text-green-600" : "text-foreground/35"
+            }`}
+        >
+          {count}/{marbles.length}
+        </span>
+      </div>
     </div>
   );
 }

--- a/components/tutorial/widgets/marble-sampling-widget.tsx
+++ b/components/tutorial/widgets/marble-sampling-widget.tsx
@@ -39,11 +39,11 @@ function StatCard({
       >
         {value}
       </span>
-      <span className={`text-center text-[11px] leading-snug ${dim ? "text-foreground/30" : "text-foreground/45"}`}>
+      <span className={`text-center text-[10px] leading-snug whitespace-nowrap sm:text-[11px] ${dim ? "text-foreground/30" : "text-foreground/45"}`}>
         {label}
       </span>
       {sub && (
-        <span className="mt-0.5 text-[10px] text-foreground/30">{sub}</span>
+        <span className="mt-0.5 text-[9px] text-foreground/30 whitespace-nowrap sm:text-[10px]">{sub}</span>
       )}
     </div>
   );

--- a/components/tutorial/widgets/marble-sampling-widget.tsx
+++ b/components/tutorial/widgets/marble-sampling-widget.tsx
@@ -251,10 +251,10 @@ export function MarbleSamplingWidget({
     totalDraws === 0 ? "Draw a sample" : "Draw another sample";
 
   return (
-    <div className="flex flex-col items-center gap-5">
+    <div className="flex w-full flex-col items-center gap-5">
 
       {/* ── Widget card ── */}
-      <div className="w-full max-w-[420px] rounded-2xl border border-foreground/10 bg-background px-6 py-5 shadow-sm">
+      <div className="mx-auto w-full max-w-[420px] rounded-2xl border border-foreground/10 bg-background px-4 py-5 shadow-sm sm:px-6">
         {/* Stats: latest | avg | true */}
         <div className="mb-4 flex items-stretch justify-center gap-1.5 border-b border-foreground/[0.08] pb-4">
           <StatCard
@@ -283,7 +283,7 @@ export function MarbleSamplingWidget({
             onClick={handleDraw}
             disabled={isAnimating}
             aria-label={`${buttonLabel}. ${totalDraws} sample${totalDraws !== 1 ? "s" : ""} drawn so far.`}
-            className="w-full rounded-[10px] bg-foreground py-3 text-sm font-semibold text-background transition-opacity hover:opacity-80 active:opacity-65 disabled:opacity-40"
+            className="w-full whitespace-nowrap rounded-[10px] bg-foreground py-3 text-sm font-semibold text-background transition-opacity hover:opacity-80 active:opacity-65 disabled:opacity-40"
           >
             {buttonLabel}
           </button>
@@ -346,18 +346,20 @@ export function MarbleSamplingWidget({
               ))}
             </div>
           ) : (
-            <div className="w-full max-w-[371px]">
+            <div className="w-full">
               {/* Column header */}
-              <div className="mb-1 flex items-center gap-[8px] border-b border-foreground/[0.08] pb-1.5 sm:gap-[10px]">
-                <span className="w-[56px] shrink-0 sm:w-[68px]" />
-                <div className="flex shrink-0 gap-[2px] sm:gap-[3px]">
-                  {Array.from({ length: N }, (_, i) => (
-                    <div key={i} className="w-[18px] text-center text-[8px] font-semibold text-foreground/25 sm:w-[22px] sm:text-[9px]">
-                      {i + 1}
-                    </div>
-                  ))}
+              <div className="mb-1 flex justify-center border-b border-foreground/[0.08] pb-1.5">
+                <div className="grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[max-content_auto_max-content]">
+                  <span className="text-right text-[10px] font-semibold text-foreground/25 sm:text-[11px]" />
+                  <div className="flex justify-center gap-[2px] sm:gap-[3px]">
+                    {Array.from({ length: N }, (_, i) => (
+                      <div key={i} className="w-[18px] text-center text-[8px] font-semibold text-foreground/25 sm:w-[22px] sm:text-[9px]">
+                        {i + 1}
+                      </div>
+                    ))}
+                  </div>
+                  <span className="text-left text-[9px] font-semibold text-foreground/25 sm:text-[10px]">hits</span>
                 </div>
-                <span className="w-8 pl-0.5 text-[9px] font-semibold text-foreground/25 sm:w-9 sm:text-[10px]">hits</span>
               </div>
 
               {/* overflow-hidden clips the fading-out row so it never adds height */}

--- a/components/tutorial/widgets/marble-sampling-widget.tsx
+++ b/components/tutorial/widgets/marble-sampling-widget.tsx
@@ -3,7 +3,6 @@
 import { useState, useRef, useEffect } from "react";
 import { drawSample, countSample, binomialMean } from "@/maths/sampling";
 import { MarbleRow } from "./marble-row";
-import { WJAR_W } from "../illustrations/jar-illustration";
 import { N, P } from "../constants/sampling-constants";
 const MAX_ROWS = 5;
 const FADE_DURATION = 250;
@@ -255,10 +254,7 @@ export function MarbleSamplingWidget({
     <div className="flex flex-col items-center gap-5">
 
       {/* ── Widget card ── */}
-      <div
-        className="rounded-2xl border border-foreground/10 bg-background px-6 py-5 shadow-sm"
-        style={{ width: WJAR_W }}
-      >
+      <div className="w-full max-w-[420px] rounded-2xl border border-foreground/10 bg-background px-6 py-5 shadow-sm">
         {/* Stats: latest | avg | true */}
         <div className="mb-4 flex items-stretch justify-center gap-1.5 border-b border-foreground/[0.08] pb-4">
           <StatCard
@@ -340,29 +336,28 @@ export function MarbleSamplingWidget({
               <span className="h-2.5 w-2.5 rounded-full bg-foreground/25 animate-bounce" />
             </div>
           ) : samples.length === 0 ? (
-            <div className="flex w-full items-center justify-center gap-[3px]">
+            <div className="flex w-full items-center justify-center gap-[2px] sm:gap-[3px]">
               {Array.from({ length: N }, (_, i) => (
                 <div
                   key={i}
                   aria-hidden="true"
-                  className="h-[22px] w-[22px] rounded-full border border-dashed border-foreground/15"
+                  className="h-[18px] w-[18px] rounded-full border border-dashed border-foreground/15 sm:h-[22px] sm:w-[22px]"
                 />
               ))}
             </div>
           ) : (
-            // Fixed-width inner block (label 68 + gap 10 + marbles 247 + gap 10 + count 36 = 371px)
-            <div className="w-[371px]">
+            <div className="w-full max-w-[371px]">
               {/* Column header */}
-              <div className="mb-1 flex items-center gap-[10px] border-b border-foreground/[0.08] pb-1.5">
-                <span className="w-[68px] shrink-0" />
-                <div className="flex shrink-0 gap-[3px]">
+              <div className="mb-1 flex items-center gap-[8px] border-b border-foreground/[0.08] pb-1.5 sm:gap-[10px]">
+                <span className="w-[56px] shrink-0 sm:w-[68px]" />
+                <div className="flex shrink-0 gap-[2px] sm:gap-[3px]">
                   {Array.from({ length: N }, (_, i) => (
-                    <div key={i} className="w-[22px] text-center text-[9px] font-semibold text-foreground/25">
+                    <div key={i} className="w-[18px] text-center text-[8px] font-semibold text-foreground/25 sm:w-[22px] sm:text-[9px]">
                       {i + 1}
                     </div>
                   ))}
                 </div>
-                <span className="w-9 pl-0.5 text-[10px] font-semibold text-foreground/25">hits</span>
+                <span className="w-8 pl-0.5 text-[9px] font-semibold text-foreground/25 sm:w-9 sm:text-[10px]">hits</span>
               </div>
 
               {/* overflow-hidden clips the fading-out row so it never adds height */}

--- a/components/tutorial/widgets/marble-sampling-widget.tsx
+++ b/components/tutorial/widgets/marble-sampling-widget.tsx
@@ -349,7 +349,7 @@ export function MarbleSamplingWidget({
             <div className="w-full">
               {/* Column header */}
               <div className="mb-1 flex justify-center border-b border-foreground/[0.08] pb-1.5">
-                <div className="grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[max-content_auto_max-content]">
+                <div className="grid items-center gap-x-[8px] sm:gap-x-[10px] grid-cols-[minmax(4ch,auto)_auto_minmax(4ch,auto)]">
                   <span className="text-right text-[10px] font-semibold text-foreground/25 sm:text-[11px]" />
                   <div className="flex justify-center gap-[2px] sm:gap-[3px]">
                     {Array.from({ length: N }, (_, i) => (

--- a/components/tutorial/widgets/widget-frame.tsx
+++ b/components/tutorial/widgets/widget-frame.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 export function WidgetFrame({ children }: { children: ReactNode }) {
   return (
-    <div className="rounded-xl border border-foreground/10 bg-foreground/[0.02] p-6">
+    <div className="w-full rounded-xl border border-foreground/10 bg-foreground/[0.02] p-4 sm:p-6">
       <div className="mb-4 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-foreground/30">
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Scale correctly on mobile;
Removes fixed 420 width;
Scaled marble row layout down on small screens so it stays centered and doesn't bleed left.
Marble illustration: Improved visual layout

Fixes #19 