### PR TITLE
Add mobile nav

### DIFF
--- a/components/tutorial/tutorial-layout.tsx
+++ b/components/tutorial/tutorial-layout.tsx
@@ -1,18 +1,74 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { TutorialNav } from "./tutorial-nav";
 
 export function TutorialLayout({ children }: { children: ReactNode }) {
   const [isNavOpen, setIsNavOpen] = useState(false);
 
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const lastActiveElementRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
-    if (!isNavOpen) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsNavOpen(false);
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
+    if (isNavOpen) {
+      // save the element that had focus so we can restore it on close
+      lastActiveElementRef.current = document.activeElement as HTMLElement | null;
+
+      // focus the close button (or dialog) on next tick
+      setTimeout(() => {
+        if (closeButtonRef.current) {
+          closeButtonRef.current.focus();
+        } else if (dialogRef.current) {
+          dialogRef.current.focus();
+        }
+      }, 0);
+
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setIsNavOpen(false);
+          return;
+        }
+
+        if (e.key === "Tab") {
+          const dialog = dialogRef.current;
+          if (!dialog) return;
+          const nodes = dialog.querySelectorAll<HTMLElement>(
+            'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([tabindex="-1"]), [contenteditable]'
+          );
+          const focusable = Array.from(nodes).filter(
+            (n) => n.offsetParent !== null
+          );
+          if (focusable.length === 0) {
+            e.preventDefault();
+            return;
+          }
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+
+          if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        }
+      };
+
+      document.addEventListener("keydown", onKeyDown);
+      return () => document.removeEventListener("keydown", onKeyDown);
+    }
+
+    // restore focus when the dialog closes
+    if (lastActiveElementRef.current) {
+      lastActiveElementRef.current.focus();
+    }
+    return;
   }, [isNavOpen]);
 
   return (
@@ -20,6 +76,7 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
       <div className="mb-6 border-b border-foreground/10 pb-4 lg:hidden">
         <button
           type="button"
+          ref={triggerRef}
           onClick={() => setIsNavOpen(true)}
           className="inline-flex items-center gap-2 rounded-full border border-foreground/15 px-4 py-2 text-sm font-medium text-foreground/70 transition hover:border-foreground/30 hover:text-foreground"
           aria-haspopup="dialog"
@@ -41,6 +98,8 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
           />
           <div
             id="tutorial-chapters-dialog"
+            ref={dialogRef}
+            tabIndex={-1}
             role="dialog"
             aria-labelledby="tutorial-chapters-title"
             aria-modal="true"
@@ -53,6 +112,7 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
               <button
                 type="button"
                 onClick={() => setIsNavOpen(false)}
+                ref={closeButtonRef}
                 className="rounded-full px-2 py-1 text-sm text-foreground/60 transition hover:text-foreground"
                 aria-label="Close chapters"
               >

--- a/components/tutorial/tutorial-layout.tsx
+++ b/components/tutorial/tutorial-layout.tsx
@@ -16,13 +16,14 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
   }, [isNavOpen]);
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-6 pb-12 pt-6 sm:pt-10">
+    <div className="mx-auto w-full max-w-5xl px-6 pb-12 pt-6">
       <div className="mb-6 border-b border-foreground/10 pb-4 lg:hidden">
         <button
           type="button"
           onClick={() => setIsNavOpen(true)}
           className="inline-flex items-center gap-2 rounded-full border border-foreground/15 px-4 py-2 text-sm font-medium text-foreground/70 transition hover:border-foreground/30 hover:text-foreground"
           aria-haspopup="dialog"
+          aria-controls="tutorial-chapters-dialog"
           aria-expanded={isNavOpen}
         >
           <span className="text-base leading-none" aria-hidden="true">
@@ -39,13 +40,14 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
             onClick={() => setIsNavOpen(false)}
           />
           <div
+            id="tutorial-chapters-dialog"
             role="dialog"
-            aria-label="Chapters"
+            aria-labelledby="tutorial-chapters-title"
             aria-modal="true"
             className="fixed left-0 top-0 z-50 h-full w-full max-w-xs border-r border-foreground/10 bg-background p-6 shadow-xl lg:hidden"
           >
             <div className="flex items-center justify-between">
-              <p className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
+              <p id="tutorial-chapters-title" className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
                 Chapters
               </p>
               <button

--- a/components/tutorial/tutorial-layout.tsx
+++ b/components/tutorial/tutorial-layout.tsx
@@ -1,10 +1,20 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { TutorialNav } from "./tutorial-nav";
 
 export function TutorialLayout({ children }: { children: ReactNode }) {
   const [isNavOpen, setIsNavOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isNavOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsNavOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isNavOpen]);
+
   return (
     <div className="mx-auto w-full max-w-5xl px-6 pb-12 pt-6 sm:pt-10">
       <div className="mb-6 border-b border-foreground/10 pb-4 lg:hidden">
@@ -21,36 +31,38 @@ export function TutorialLayout({ children }: { children: ReactNode }) {
           Chapters
         </button>
       </div>
-      <div
-        className={`fixed inset-0 z-40 bg-black/30 transition-opacity lg:hidden ${isNavOpen ? "opacity-100" : "pointer-events-none opacity-0"
-          }`}
-        aria-hidden={!isNavOpen}
-        onClick={() => setIsNavOpen(false)}
-      />
-      <div
-        role="dialog"
-        aria-label="Chapters"
-        aria-modal="true"
-        className={`fixed left-0 top-0 z-50 h-full w-full max-w-xs border-r border-foreground/10 bg-background p-6 shadow-xl transition-transform lg:hidden ${isNavOpen ? "translate-x-0" : "-translate-x-full"
-          }`}
-      >
-        <div className="flex items-center justify-between">
-          <p className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
-            Chapters
-          </p>
-          <button
-            type="button"
+      {isNavOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/30 lg:hidden"
+            aria-hidden="true"
             onClick={() => setIsNavOpen(false)}
-            className="rounded-full px-2 py-1 text-sm text-foreground/60 transition hover:text-foreground"
-            aria-label="Close chapters"
+          />
+          <div
+            role="dialog"
+            aria-label="Chapters"
+            aria-modal="true"
+            className="fixed left-0 top-0 z-50 h-full w-full max-w-xs border-r border-foreground/10 bg-background p-6 shadow-xl lg:hidden"
           >
-            Close
-          </button>
-        </div>
-        <div className="mt-4">
-          <TutorialNav compactNav onNavigate={() => setIsNavOpen(false)} />
-        </div>
-      </div>
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
+                Chapters
+              </p>
+              <button
+                type="button"
+                onClick={() => setIsNavOpen(false)}
+                className="rounded-full px-2 py-1 text-sm text-foreground/60 transition hover:text-foreground"
+                aria-label="Close chapters"
+              >
+                Close
+              </button>
+            </div>
+            <div className="mt-4">
+              <TutorialNav compactNav onNavigate={() => setIsNavOpen(false)} />
+            </div>
+          </div>
+        </>
+      )}
       <div className="flex gap-12">
         <div className="min-w-0 flex-1">{children}</div>
         <aside className="hidden w-52 shrink-0 lg:block">

--- a/components/tutorial/tutorial-layout.tsx
+++ b/components/tutorial/tutorial-layout.tsx
@@ -1,11 +1,55 @@
-import type { ReactNode } from "react";
+"use client";
+
+import { useState, type ReactNode } from "react";
 import { TutorialNav } from "./tutorial-nav";
 
 export function TutorialLayout({ children }: { children: ReactNode }) {
+  const [isNavOpen, setIsNavOpen] = useState(false);
   return (
-    <div className="mx-auto w-full max-w-5xl px-6 py-12">
+    <div className="mx-auto w-full max-w-5xl px-6 pb-12 pt-6 sm:pt-10">
       <div className="mb-6 border-b border-foreground/10 pb-4 lg:hidden">
-        <TutorialNav horizontal />
+        <button
+          type="button"
+          onClick={() => setIsNavOpen(true)}
+          className="inline-flex items-center gap-2 rounded-full border border-foreground/15 px-4 py-2 text-sm font-medium text-foreground/70 transition hover:border-foreground/30 hover:text-foreground"
+          aria-haspopup="dialog"
+          aria-expanded={isNavOpen}
+        >
+          <span className="text-base leading-none" aria-hidden="true">
+            ≡
+          </span>
+          Chapters
+        </button>
+      </div>
+      <div
+        className={`fixed inset-0 z-40 bg-black/30 transition-opacity lg:hidden ${isNavOpen ? "opacity-100" : "pointer-events-none opacity-0"
+          }`}
+        aria-hidden={!isNavOpen}
+        onClick={() => setIsNavOpen(false)}
+      />
+      <div
+        role="dialog"
+        aria-label="Chapters"
+        aria-modal="true"
+        className={`fixed left-0 top-0 z-50 h-full w-full max-w-xs border-r border-foreground/10 bg-background p-6 shadow-xl transition-transform lg:hidden ${isNavOpen ? "translate-x-0" : "-translate-x-full"
+          }`}
+      >
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold uppercase tracking-widest text-foreground/40">
+            Chapters
+          </p>
+          <button
+            type="button"
+            onClick={() => setIsNavOpen(false)}
+            className="rounded-full px-2 py-1 text-sm text-foreground/60 transition hover:text-foreground"
+            aria-label="Close chapters"
+          >
+            Close
+          </button>
+        </div>
+        <div className="mt-4">
+          <TutorialNav compactNav onNavigate={() => setIsNavOpen(false)} />
+        </div>
       </div>
       <div className="flex gap-12">
         <div className="min-w-0 flex-1">{children}</div>

--- a/components/tutorial/tutorial-nav.tsx
+++ b/components/tutorial/tutorial-nav.tsx
@@ -4,30 +4,36 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { chapters } from "./chapters";
 
-export function TutorialNav({ horizontal = false }: { horizontal?: boolean }) {
+export function TutorialNav({
+  compactNav = false,
+  onNavigate,
+}: {
+  compactNav?: boolean;
+  onNavigate?: () => void;
+}) {
   const pathname = usePathname();
 
-  if (horizontal) {
+  if (compactNav) {
     return (
       <nav aria-label="Chapters">
-        <ol className="grid grid-cols-2 gap-2 pb-1 sm:flex sm:gap-2 sm:overflow-x-auto">
+        <ol className="space-y-2 pb-1">
           {chapters.map((ch) => {
             const active = pathname === ch.href;
             return (
-              <li key={ch.href} className="sm:shrink-0">
+              <li key={ch.href}>
                 <Link
                   href={ch.href}
                   aria-current={active ? "page" : undefined}
-                  className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-[13px] transition-colors sm:text-sm ${
-                    active
+                  onClick={onNavigate}
+                  className={`flex w-full items-center gap-2 rounded-full px-3 py-1.5 text-[13px] transition-colors sm:text-sm ${active
                       ? "bg-foreground/[0.08] font-medium text-foreground"
                       : "text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/70"
-                  }`}
+                    }`}
                 >
                   <span className="tabular-nums text-foreground/30">
                     {ch.number}
                   </span>
-                  <span className="truncate">{ch.shortTitle}</span>
+                  <span className="leading-snug">{ch.shortTitle}</span>
                 </Link>
               </li>
             );
@@ -50,11 +56,11 @@ export function TutorialNav({ horizontal = false }: { horizontal?: boolean }) {
               <Link
                 href={ch.href}
                 aria-current={active ? "page" : undefined}
-                className={`flex gap-3 rounded-md px-3 py-2 text-sm transition-colors ${
-                  active
-                    ? "bg-foreground/[0.07] font-medium text-foreground"
-                    : "text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70"
-                }`}
+                onClick={onNavigate}
+                className={`flex gap-3 rounded-md px-3 py-2 text-sm transition-colors ${active
+                  ? "bg-foreground/[0.07] font-medium text-foreground"
+                  : "text-foreground/50 hover:bg-foreground/[0.04] hover:text-foreground/70"
+                  }`}
               >
                 <span className="shrink-0 tabular-nums text-foreground/30">
                   {ch.number}

--- a/components/tutorial/tutorial-nav.tsx
+++ b/components/tutorial/tutorial-nav.tsx
@@ -10,15 +10,15 @@ export function TutorialNav({ horizontal = false }: { horizontal?: boolean }) {
   if (horizontal) {
     return (
       <nav aria-label="Chapters">
-        <ol className="flex gap-2 overflow-x-auto pb-1">
+        <ol className="grid grid-cols-2 gap-2 pb-1 sm:flex sm:gap-2 sm:overflow-x-auto">
           {chapters.map((ch) => {
             const active = pathname === ch.href;
             return (
-              <li key={ch.href} className="shrink-0">
+              <li key={ch.href} className="sm:shrink-0">
                 <Link
                   href={ch.href}
                   aria-current={active ? "page" : undefined}
-                  className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-colors ${
+                  className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-[13px] transition-colors sm:text-sm ${
                     active
                       ? "bg-foreground/[0.08] font-medium text-foreground"
                       : "text-foreground/40 hover:bg-foreground/[0.04] hover:text-foreground/70"
@@ -27,7 +27,7 @@ export function TutorialNav({ horizontal = false }: { horizontal?: boolean }) {
                   <span className="tabular-nums text-foreground/30">
                     {ch.number}
                   </span>
-                  <span>{ch.shortTitle}</span>
+                  <span className="truncate">{ch.shortTitle}</span>
                 </Link>
               </li>
             );

--- a/components/tutorial/widgets/calculator-widget.tsx
+++ b/components/tutorial/widgets/calculator-widget.tsx
@@ -363,7 +363,7 @@ export function CalculatorWidget() {
           </li>
           <li>
             <strong className="text-foreground/75">Power fixed at 80%.</strong>{" "}
-            Power is the chance of catching a real win if one exists. We lock it at 80% here and leave that lever for a later versions of the calculator.
+            Power is the chance of catching a real win if one exists. We lock it at 80% here and leave that lever for a later version of the calculator.
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Fixes cut off mobile nav. Replaces the horizontal version with a proper side drawer (opened by hamburger button).
Keeps using the short version of the chapter titles, but stacked vertically.
This introduces a clean mobile layout, while keeping the side bar (to the right) for wider screens.