### PR TITLE
Change api host to own subdomain

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,7 +1,7 @@
 import posthog from "posthog-js";
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_TOKEN!, {
-  api_host: "/ingest",
+  api_host: "https://z.learnabtest.org",
   ui_host: "https://eu.posthog.com",
   defaults: "2026-01-30",
   capture_exceptions: true,


### PR DESCRIPTION
change to own subdomain which has a reverse proxy set up in posthog. avoids routing through posthog. reduces chance of getting blocked by ad blockers.